### PR TITLE
Add getConnectedDevices utility function

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,6 @@
 import { default as Usbmux } from './lib/usbmux/usbmux';
+import { getConnectedDevices } from './lib/utilities';
 
-export { Usbmux };
+
+export { Usbmux, getConnectedDevices };
+export default Usbmux;

--- a/lib/usbmux/transformer/usbmux-decoder.js
+++ b/lib/usbmux/transformer/usbmux-decoder.js
@@ -1,3 +1,4 @@
+/* eslint-disable promise/prefer-await-to-callbacks */
 import { parse } from '../../util/plist';
 import Stream from 'stream';
 

--- a/lib/usbmux/transformer/usbmux-encoder.js
+++ b/lib/usbmux/transformer/usbmux-encoder.js
@@ -1,3 +1,4 @@
+/* eslint-disable promise/prefer-await-to-callbacks */
 import Stream from 'stream';
 import { createPlist } from '../../util/plist';
 

--- a/lib/usbmux/usbmux.js
+++ b/lib/usbmux/usbmux.js
@@ -5,10 +5,21 @@ import { parse } from '../util/plist.js';
 import LengthBasedSplitter from '../util/transformer/length-based-splitter';
 import UsbmuxDecoder from './transformer/usbmux-decoder.js';
 import UsbmuxEncoder from './transformer/usbmux-encoder.js';
+import path from 'path';
+
+
+let name, version;
+try {
+  // first try assuming this is in the `build` folder
+  ({ name, version } = require(path.resolve(__dirname, '..', '..', '..', 'package.json')));
+} catch (err) {
+  // then try assuming it is not
+  ({ name, version } = require(path.resolve(__dirname, '..', '..', 'package.json')));
+}
 
 const DEFAULT_USBMUXD_SOCKET = '/var/run/usbmuxd';
-const PROG_NAME = 'appium-ios-device';
-const CLIENT_VERSION_STRING = 'appium-ios-device';
+const PROG_NAME = name;
+const CLIENT_VERSION_STRING = `${name}-${version}`;
 
 function swap16 (val) {
   return ((val & 0xFF) << 8) | ((val >> 8) & 0xFF);

--- a/lib/util/transformer/length-based-splitter.js
+++ b/lib/util/transformer/length-based-splitter.js
@@ -1,3 +1,4 @@
+/* eslint-disable promise/prefer-await-to-callbacks */
 import Stream from 'stream';
 
 class LengthBasedSplitter extends Stream.Transform {

--- a/lib/utilities.js
+++ b/lib/utilities.js
@@ -4,10 +4,13 @@ import _ from 'lodash';
 
 async function getConnectedDevices (socket) {
   const usbmux = new Usbmux(socket);
-  const devices = await usbmux.listDevices();
-  usbmux.close();
-  const udids = devices.map((device) => device.Properties.SerialNumber);
-  return _.uniq(udids);
+  try {
+    const devices = await usbmux.listDevices();
+    const udids = devices.map((device) => device.Properties.SerialNumber);
+    return _.uniq(udids);
+  } finally {
+    usbmux.close();
+  }
 }
 
 export { getConnectedDevices };

--- a/lib/utilities.js
+++ b/lib/utilities.js
@@ -1,0 +1,13 @@
+import Usbmux from './usbmux/usbmux';
+import _ from 'lodash';
+
+
+async function getConnectedDevices (socket) {
+  const usbmux = new Usbmux(socket);
+  const devices = await usbmux.listDevices();
+  usbmux.close();
+  const udids = devices.map((device) => device.Properties.SerialNumber);
+  return _.uniq(udids);
+}
+
+export { getConnectedDevices };

--- a/test/usbmux/usbmux-specs.js
+++ b/test/usbmux/usbmux-specs.js
@@ -26,7 +26,7 @@ describe('usbmux', function () {
     this.server.close();
   });
 
-  it('read usbmux message', async function () {
+  it('should read usbmux message', async function () {
     this.server.on('connection', function (socketClient) {
       socketClient.write(deviceListFixture);
     });
@@ -34,7 +34,7 @@ describe('usbmux', function () {
     devices.length.should.be.equal(1);
   });
 
-  it('read concatanated message', async function () {
+  it('should read concatanated message', async function () {
     let doubleContent = Buffer.concat([deviceListFixture, deviceListFixture]);
     this.server.on('connection', function (socketClient) {
       socketClient.write(doubleContent);
@@ -45,7 +45,7 @@ describe('usbmux', function () {
     devices.length.should.be.equal(1);
   });
 
-  it('find correct device', async function () {
+  it('should find correct device', async function () {
     this.server.on('connection', function (socketClient) {
       socketClient.write(deviceListFixture);
     });

--- a/test/utilities-specs.js
+++ b/test/utilities-specs.js
@@ -1,0 +1,36 @@
+import { getConnectedDevices } from '..';
+import { fs } from 'appium-support';
+import path from 'path';
+import net from 'net';
+import chai from 'chai';
+
+
+chai.should();
+
+
+
+describe('usbmux', function () {
+  let server;
+  let socket;
+
+  before(async function () {
+    const file = path.resolve(__dirname, '..', '..', 'test', 'fixtures', 'usbmuxlistdevicemessage.bin');
+    const deviceListFixture = await fs.readFile(file);
+
+    server = net.createServer();
+    server.listen();
+    server.on('connection', function (socketClient) {
+      socketClient.write(deviceListFixture);
+    });
+
+    socket = net.connect(server.address());
+  });
+  after(function () {
+    server.close();
+  });
+
+  it('should get unique udids', async function () {
+    const udids = await getConnectedDevices(socket);
+    udids.length.should.be.equal(1);
+  });
+});


### PR DESCRIPTION
Add a little utility function, `getConnectedDevices`, to get just the connected udids without the client needing to know anything about dealing with the module (e.g., instantiating, finding the correct key for udid, etc.). This will allow us to replace https://github.com/appium/appium-xcuitest-driver/blob/master/lib/real-device-management.js#L6-L20 and get rid of the dependency on `idevice_id` in `appium-xcuitest-driver`.