### PR TITLE
docs(readme): add Greenkeeper badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 appium-ios-device
 ===================
 
+[![Greenkeeper badge](https://badges.greenkeeper.io/appium/appium-ios-device.svg)](https://greenkeeper.io/)
+
 Work in progress, stay tuned!
 
 ## Watch


### PR DESCRIPTION
I don't know why Greenkeeper isn't doing this... I'll contact support.