### PR TITLE
Refactor and add SSL enabled service support

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,8 +1,7 @@
 import { default as Usbmux } from './lib/usbmux';
-import { getConnectedDevices, getOSVersion, getDeviceTime, startLockdownSession,
-         startSyslogService, startWebInspectorService, connectPort } from './lib/utilities';
+import * as utilities from './lib/utilities';
+import * as services from './lib/services';
 
 
-export { Usbmux, getConnectedDevices, getOSVersion, getDeviceTime, startLockdownSession,
-  startSyslogService, startWebInspectorService, connectPort };
+export { Usbmux, utilities, services };
 export default Usbmux;

--- a/lib/plist-service/index.js
+++ b/lib/plist-service/index.js
@@ -1,10 +1,8 @@
-import tls from 'tls';
 import B from 'bluebird';
+import { upgradeToSSL } from '../ssl-helper';
 import PlistServiceEncoder from './transformer/plist-service-encoder';
 import PlistServiceDecoder from './transformer/plist-service-decoder';
 import LengthBasedSplitter from '../util/transformer/length-based-splitter';
-
-const TLS_VERSION = 'TLSv1_method';
 
 class PlistService {
   constructor (socketClient) {
@@ -15,7 +13,6 @@ class PlistService {
 
     this._encoder = new PlistServiceEncoder();
     this._encoder.pipe(this._socketClient);
-
   }
 
   async sendPlistAndReceive (json, timeout = 5000) {
@@ -39,14 +36,7 @@ class PlistService {
     this._socketClient.unpipe(this._splitter);
     this._splitter.unpipe(this._decoder);
     this._encoder.unpipe(this._socketClient);
-    this._socketClient = new tls.TLSSocket(this._socketClient, {
-      secureContext: tls.createSecureContext({
-        key: hostPrivateKey,
-        cert: hostCertificate,
-        rejectUnauthorized: false,
-        secureProtocol: TLS_VERSION
-      })
-    });
+    this._socketClient = upgradeToSSL(this._socketClient, hostPrivateKey, hostCertificate);
     this._encoder.pipe(this._socketClient);
     this._socketClient.pipe(this._splitter).pipe(this._decoder);
   }

--- a/lib/services.js
+++ b/lib/services.js
@@ -1,0 +1,27 @@
+import { connectPort, connectPortSSL, startLockdownSession } from './utilities';
+import { SyslogService, SYSLOG_SERVICE_NAME } from './syslog';
+import { WebInspectorService, WEB_INSPECTOR_SERVICE_NAME } from './webinspector';
+
+async function startSyslogService (udid, socket) {
+  return new SyslogService(await startService(udid, SYSLOG_SERVICE_NAME, socket));
+}
+
+async function startWebInspectorService (udid, socket) {
+  return new WebInspectorService(await startService(udid, WEB_INSPECTOR_SERVICE_NAME, socket));
+}
+
+async function startService (udid, serviceName, socket) {
+  const lockdown = await startLockdownSession(udid, socket);
+  try {
+    const service = await lockdown.startService(serviceName);
+    if (service.EnableServiceSSL) {
+      return await connectPortSSL(udid, service.Port, socket);
+    } else {
+      return await connectPort(udid, service.Port, socket);
+    }
+  } finally {
+    lockdown.close();
+  }
+}
+
+export { startSyslogService, startWebInspectorService };

--- a/lib/ssl-helper.js
+++ b/lib/ssl-helper.js
@@ -1,0 +1,16 @@
+import tls from 'tls';
+
+const TLS_VERSION = 'TLSv1_method';
+
+function upgradeToSSL (socket, key, cert) {
+  return new tls.TLSSocket(socket, {
+    secureContext: tls.createSecureContext({
+      key,
+      cert,
+      rejectUnauthorized: false,
+      secureProtocol: TLS_VERSION
+    })
+  });
+}
+export { upgradeToSSL };
+

--- a/lib/utilities.js
+++ b/lib/utilities.js
@@ -1,12 +1,12 @@
 import Usbmux from './usbmux';
-import { SyslogService, SYSLOG_SERVICE_NAME } from './syslog';
-import { WebInspectorService, WEB_INSPECTOR_SERVICE_NAME } from './webinspector';
+import { upgradeToSSL } from './ssl-helper';
 import _ from 'lodash';
 
 const LOCKDOWN_REQUEST = {
   DEVICE_TIME: { Key: 'TimeIntervalSince1970' },
   DEVICE_NAME: { Key: 'ProductVersion' }
 };
+
 async function getConnectedDevices (socket) {
   const usbmux = new Usbmux(socket);
   try {
@@ -58,6 +58,26 @@ async function startLockdownSession (udid, socket) {
     throw e;
   }
 }
+
+async function connectPortSSL (udid, port, socket) {
+  const usbmux = new Usbmux(socket);
+  try {
+    const device = await usbmux.findDevice(udid);
+    if (!device) {
+      throw new Error(`Couldn't find the expected device ${udid}`);
+    }
+    const pairRecord = await usbmux.readPairRecord(udid);
+    if (!pairRecord) {
+      throw new Error(`Couldn't find a pair record for device ${udid}. Please first pair with the device`);
+    }
+    const socket = await usbmux.connect(device.Properties.DeviceID, port);
+    return upgradeToSSL(socket, pairRecord.HostPrivateKey, pairRecord.HostCertificate);
+  } catch (e) {
+    usbmux.close();
+    throw e;
+  }
+}
+
 async function connectPort (udid, port, socket) {
   const usbmux = new Usbmux(socket);
   try {
@@ -72,24 +92,4 @@ async function connectPort (udid, port, socket) {
   }
 }
 
-async function startSyslogService (udid, socket) {
-  const lockdown = await startLockdownSession(udid, socket);
-  try {
-    const service = await lockdown.startService(SYSLOG_SERVICE_NAME);
-    return new SyslogService(await connectPort(udid, service.Port, socket));
-  } finally {
-    lockdown.close();
-  }
-}
-
-async function startWebInspectorService (udid, socket) {
-  const lockdown = await startLockdownSession(udid, socket);
-  try {
-    const service = await lockdown.startService(WEB_INSPECTOR_SERVICE_NAME);
-    return new WebInspectorService(await connectPort(udid, service.Port, socket));
-  } finally {
-    lockdown.close();
-  }
-}
-
-export { getConnectedDevices, getOSVersion, getDeviceTime, startLockdownSession, startSyslogService, startWebInspectorService, connectPort };
+export { getConnectedDevices, getOSVersion, getDeviceTime, startLockdownSession, connectPort, connectPortSSL };

--- a/test/utilities-specs.js
+++ b/test/utilities-specs.js
@@ -1,4 +1,4 @@
-import { getConnectedDevices, getOSVersion } from '..';
+import { utilities } from '..';
 import chai from 'chai';
 import { getServerWithFixtures, fixtures, UDID } from './fixtures';
 
@@ -17,14 +17,14 @@ describe('utilities', function () {
 
   it('should get unique udids', async function () {
     ({server, socket} = await getServerWithFixtures(fixtures.DEVICE_LIST));
-    const udids = await getConnectedDevices(socket);
+    const udids = await utilities.getConnectedDevices(socket);
     udids.length.should.be.equal(1);
     udids[0].should.eql(UDID);
   });
 
   it('should get product version', async function () {
     ({server, socket} = await getServerWithFixtures(fixtures.DEVICE_LIST, fixtures.DEVICE_CONNECT, fixtures.LOCKDOWN_GET_VALUE_OS_VERSION));
-    const osVersion = await getOSVersion(UDID, socket);
+    const osVersion = await utilities.getOSVersion(UDID, socket);
     osVersion.should.be.equal('12.3.1');
   });
 });


### PR DESCRIPTION
* Create a services object in order to avoid creating too many exports
* Create an utilities object to be consistent with the services object
* Create a ssl-helper since lockdown ssl and service ssl are shared
* Add ssl support for services which is mainly used in iOS 13