### PR TITLE
refactor: Pass opts to service creation functions

### DIFF
--- a/lib/services.js
+++ b/lib/services.js
@@ -18,19 +18,13 @@ async function startSimulateLocationService (udid, opts = {}) {
 }
 
 async function startWebInspectorService (udid, opts = {}) {
-  let majorOsVersion = opts.majorOsVersion;
-  if (!majorOsVersion) {
-    const osVersion = await getOSVersion(udid, opts.socket);
-    const semverVersion = semver.coerce(osVersion);
-    if (!semverVersion) {
-      throw new Error(`Could not create a semver version out of '${osVersion}'`);
-    }
-    majorOsVersion = semverVersion.major;
+  const osVersion = opts.osVersion || await getOSVersion(udid, opts.socket);
+  const semverVersion = semver.coerce(osVersion);
+  if (!semverVersion) {
+    throw new Error(`Could not create a semver version out of '${osVersion}'`);
   }
-  const socketClient = opts.isSimulator
-    ? opts.socket
-    : await startService(udid, WEB_INSPECTOR_SERVICE_NAME, opts.socket);
-  return new WebInspectorService(majorOsVersion, socketClient);
+  const socketClient = opts.socket || await startService(udid, WEB_INSPECTOR_SERVICE_NAME);
+  return new WebInspectorService(semverVersion.major, socketClient);
 }
 
 async function startInstallationProxyService (udid, opts = {}) {

--- a/lib/services.js
+++ b/lib/services.js
@@ -27,7 +27,10 @@ async function startWebInspectorService (udid, opts = {}) {
     }
     majorOsVersion = semverVersion.major;
   }
-  return new WebInspectorService(majorOsVersion, await startService(udid, WEB_INSPECTOR_SERVICE_NAME, opts.socket));
+  const socketClient = opts.isSimulator
+    ? opts.socket
+    : await startService(udid, WEB_INSPECTOR_SERVICE_NAME, opts.socket);
+  return new WebInspectorService(majorOsVersion, socketClient);
 }
 
 async function startInstallationProxyService (udid, opts = {}) {

--- a/lib/services.js
+++ b/lib/services.js
@@ -13,8 +13,8 @@ async function startSyslogService (udid, opts = {}) {
   return new SyslogService(await startService(udid, SYSLOG_SERVICE_NAME, opts.socket));
 }
 
-async function startSimulateLocationService (udid, socket) {
-  return new SimulateLocationService(await startService(udid, SIMULATE_LOCATION_SERVICE_NAME, socket));
+async function startSimulateLocationService (udid, opts = {}) {
+  return new SimulateLocationService(await startService(udid, SIMULATE_LOCATION_SERVICE_NAME, opts.socket));
 }
 
 async function startWebInspectorService (udid, opts = {}) {

--- a/lib/services.js
+++ b/lib/services.js
@@ -9,37 +9,41 @@ import { HouseArrestService, HOUSE_ARREST_SERVICE_NAME } from './house-arrest';
 import PlistService from './plist-service';
 import semver from 'semver';
 
-async function startSyslogService (udid, socket) {
-  return new SyslogService(await startService(udid, SYSLOG_SERVICE_NAME, socket));
+async function startSyslogService (udid, opts = {}) {
+  return new SyslogService(await startService(udid, SYSLOG_SERVICE_NAME, opts.socket));
 }
 
 async function startSimulateLocationService (udid, socket) {
   return new SimulateLocationService(await startService(udid, SIMULATE_LOCATION_SERVICE_NAME, socket));
 }
 
-async function startWebInspectorService (udid, socket) {
-  const osVersion = await getOSVersion(udid, socket);
-  const semverVersion = semver.coerce(osVersion);
-  if (!semverVersion) {
-    throw new Error(`Couldn't create a semver version out of ${osVersion}`);
+async function startWebInspectorService (udid, opts = {}) {
+  let majorOsVersion = opts.majorOsVersion;
+  if (!majorOsVersion) {
+    const osVersion = await getOSVersion(udid, opts.socket);
+    const semverVersion = semver.coerce(osVersion);
+    if (!semverVersion) {
+      throw new Error(`Could not create a semver version out of '${osVersion}'`);
+    }
+    majorOsVersion = semverVersion.major;
   }
-  return new WebInspectorService(semverVersion.major, await startService(udid, WEB_INSPECTOR_SERVICE_NAME, socket));
+  return new WebInspectorService(majorOsVersion, await startService(udid, WEB_INSPECTOR_SERVICE_NAME, opts.socket));
 }
 
-async function startInstallationProxyService (udid, socket) {
-  return new InstallationProxyService(new PlistService(await startService(udid, INSTALLATION_PROXY_SERVICE_NAME, socket)));
+async function startInstallationProxyService (udid, opts = {}) {
+  return new InstallationProxyService(new PlistService(await startService(udid, INSTALLATION_PROXY_SERVICE_NAME, opts.socket)));
 }
 
-async function startAfcService (udid, socket) {
-  return new AfcService(await startService(udid, AFC_SERVICE_NAME, socket));
+async function startAfcService (udid, opts = {}) {
+  return new AfcService(await startService(udid, AFC_SERVICE_NAME, opts.socket));
 }
 
-async function startNotificationProxyService (udid, socket) {
-  return new NotificationProxyService(await startService(udid, NOTIFICATION_PROXY_SERVICE_NAME, socket));
+async function startNotificationProxyService (udid, opts = {}) {
+  return new NotificationProxyService(await startService(udid, NOTIFICATION_PROXY_SERVICE_NAME, opts.socket));
 }
 
-async function startHouseArrestService (udid, socket) {
-  return new HouseArrestService(await startService(udid, HOUSE_ARREST_SERVICE_NAME, socket));
+async function startHouseArrestService (udid, opts = {}) {
+  return new HouseArrestService(await startService(udid, HOUSE_ARREST_SERVICE_NAME, opts.socket));
 }
 
 async function startService (udid, serviceName, socket) {


### PR DESCRIPTION
Shift from passing `socket` in as a named parameter, to passing an object that might have a `socket` property.

Also add another property for the `startWebInspectorService` function, to pass in the major OS version if we have it. This will allow us to use the function with sims (where we cannot get the OS version from this package).

As far as I can tell, in current usage the `socket` argument is not actually being used.