### PR TITLE
fix: bump max frame size for web inspector service

### DIFF
--- a/lib/util/transformer/length-based-splitter.js
+++ b/lib/util/transformer/length-based-splitter.js
@@ -21,7 +21,6 @@ class LengthBasedSplitter extends Stream.Transform {
   }
 
   _decode (data, pos) {
-
     let bufferMarker = pos;
 
     let bytesToRead = Math.max((this.lengthFieldOffset + this.lengthFieldLength) - this._frameBufferIndex, 0);

--- a/lib/webinspector/index.js
+++ b/lib/webinspector/index.js
@@ -11,6 +11,8 @@ const WEB_INSPECTOR_SERVICE_NAME = 'com.apple.webinspector';
 
 const PARTIAL_MESSAGE_SUPPORT_DEPRECATION_VERSION = 11;
 
+const MAX_FRAME_SIZE = 20000000;
+
 class WebInspectorService {
 
   /**
@@ -25,7 +27,7 @@ class WebInspectorService {
       // 1MB as buffer for bulding webinspector full messages. We can increase the value if more buffer is needed
       this._decoder = new WebInspectorDecoder(MB);
       const plistDecoder = new PlistServiceDecoder();
-      const splitter = new LengthBasedSplitter(false, 1000000, 0, 4, 4);
+      const splitter = new LengthBasedSplitter(false, MAX_FRAME_SIZE, 0, 4, 4);
       this._socketClient.pipe(splitter).pipe(plistDecoder).pipe(this._decoder);
 
       this._encoder = new WebInspectorEncoder();
@@ -33,7 +35,7 @@ class WebInspectorService {
       this._encoder.pipe(plistEncoder).pipe(this._socketClient);
     } else {
       this._decoder = new PlistServiceDecoder();
-      const splitter = new LengthBasedSplitter(false, 1000000, 0, 4, 4);
+      const splitter = new LengthBasedSplitter(false, MAX_FRAME_SIZE, 0, 4, 4);
       this._socketClient.pipe(splitter).pipe(this._decoder);
 
       this._encoder = new PlistServiceEncoder();


### PR DESCRIPTION
When things like `source` for large webpage are called, it can overflow the maximum frame buffer.

This bumps it up to a still-reasonable value.

I will work on making this configurable to the end-user, but for now bigger will work.

Should fix https://github.com/appium/appium/issues/13229