### PR TITLE
fix: prefer socket.end call to socket.destroy

### DIFF
--- a/lib/afc/index.js
+++ b/lib/afc/index.js
@@ -325,7 +325,7 @@ class AfcService {
    * Closes the underlying socket communicating with the phone
    */
   close () {
-    this._socketClient.destroy();
+    this._socketClient.end();
   }
 }
 

--- a/lib/house-arrest/index.js
+++ b/lib/house-arrest/index.js
@@ -71,7 +71,7 @@ class HouseArrestService {
    * Closes the underlying socket communicating with the phone
    */
   close () {
-    this._socketClient.destroy();
+    this._socketClient.end();
   }
 }
 

--- a/lib/notification-proxy/index.js
+++ b/lib/notification-proxy/index.js
@@ -92,7 +92,7 @@ class NotificationProxyService {
    */
   close () {
     this.shutdown();
-    this._socketClient.destroy();
+    this._socketClient.end();
   }
 
 }

--- a/lib/plist-service/index.js
+++ b/lib/plist-service/index.js
@@ -65,7 +65,7 @@ class PlistService {
   }
 
   close () {
-    this._socketClient.destroy();
+    this._socketClient.end();
   }
 }
 

--- a/lib/simulatelocation/index.js
+++ b/lib/simulatelocation/index.js
@@ -43,7 +43,7 @@ class SimulateLocationService {
    * Closes the underlying socket communicating with the phone
    */
   close () {
-    this._socketClient.destroy();
+    this._socketClient.end();
   }
 
 }

--- a/lib/syslog/index.js
+++ b/lib/syslog/index.js
@@ -33,7 +33,7 @@ class SyslogService {
    * Closes the underlying socket communicating with the phone
    */
   close () {
-    this._socketClient.destroy();
+    this._socketClient.end();
   }
 
 }

--- a/lib/usbmux/index.js
+++ b/lib/usbmux/index.js
@@ -189,7 +189,7 @@ class Usbmux {
    * Closes the underlying socket communicating to the usbmuxd
    */
   close () {
-    this._socketClient.destroy();
+    this._socketClient.end();
   }
 }
 

--- a/lib/webinspector/index.js
+++ b/lib/webinspector/index.js
@@ -72,7 +72,7 @@ class WebInspectorService {
    * Closes the underlying socket communicating with the phone
    */
   close () {
-    this._socketClient.destroy();
+    this._socketClient.end();
   }
 
 }


### PR DESCRIPTION
The original problem has been uncovered by @KazuCocoa while checking https://github.com/appium/appium-xcuitest-driver/pull/1094

By calling socket.destroy we never send the FIN packet, so the server only closes connection after the timeout (30 seconds). See https://stackoverflow.com/questions/49268934/socket-in-close-wait-for-node-js-client for more details. In general, the `destroy` method of `net.Socket` is only recommended to be called in exceptional situations.