### PR TITLE
refactor: move shared service code into base classes

### DIFF
--- a/lib/afc/index.js
+++ b/lib/afc/index.js
@@ -8,16 +8,18 @@ import { MB } from '../constants';
 import B from 'bluebird';
 import path from 'path';
 import _ from 'lodash';
+import { BaseServiceSocket } from '../base-service';
+
 
 const AFC_SERVICE_NAME = 'com.apple.afc';
 
 const NULL_DELIMETER_CODE = 0x00;
 const IGNORED_PATHS = ['.', '..'];
 
-class AfcService {
-
+class AfcService extends BaseServiceSocket {
   constructor (socketClient) {
-    this._socketClient = socketClient;
+    super(socketClient);
+
     this._splitter = new LengthBasedSplitter(true, MB, 8, 8, -8);
     this._decoder = new AfcDecoder();
     this._socketClient.pipe(this._splitter).pipe(this._decoder);
@@ -319,13 +321,6 @@ class AfcService {
       setTimeout(() => reject(new Error(`Cound't finish the operation "${message}". Failed to receive any data within the timeout: ${timeout}`)), timeout);
     });
     return { packetNumber, response };
-  }
-
-  /**
-   * Closes the underlying socket communicating with the phone
-   */
-  close () {
-    this._socketClient.end();
   }
 }
 

--- a/lib/base-service.js
+++ b/lib/base-service.js
@@ -1,0 +1,28 @@
+class BaseServiceSocket {
+  constructor (socketClient) {
+    this._socketClient = socketClient;
+  }
+
+  /**
+   * Closes the underlying socket communicating with the phone
+   */
+  close () {
+    this._socketClient.end();
+  }
+}
+
+class BaseServicePlist {
+  constructor (plistService) {
+    this._plistService = plistService;
+  }
+
+  /**
+   * Closes the underlying socket communicating with the phone
+   */
+  close () {
+    this._plistService.close();
+  }
+}
+
+
+export { BaseServiceSocket, BaseServicePlist };

--- a/lib/house-arrest/index.js
+++ b/lib/house-arrest/index.js
@@ -4,12 +4,15 @@ import LengthBasedSplitter from '../util/transformer/length-based-splitter';
 import { KB } from '../constants';
 import AfcService from '../afc';
 import B from 'bluebird';
+import { BaseServiceSocket } from '../base-service';
+
 
 const HOUSE_ARREST_SERVICE_NAME = 'com.apple.mobile.house_arrest';
 
-class HouseArrestService {
+class HouseArrestService extends BaseServiceSocket {
   constructor (socketClient) {
-    this._socketClient = socketClient;
+    super(socketClient);
+
     this._decoder = new PlistServiceDecoder();
     this._splitter = new LengthBasedSplitter(false, KB, 0, 4, 4);
     this._socketClient.pipe(this._splitter).pipe(this._decoder);
@@ -66,15 +69,7 @@ class HouseArrestService {
       setTimeout(() => reject(new Error(`Failed to receive any data within the timeout: ${timeout}`)), timeout);
     });
   }
-
-  /**
-   * Closes the underlying socket communicating with the phone
-   */
-  close () {
-    this._socketClient.end();
-  }
 }
 
 export { HouseArrestService, HOUSE_ARREST_SERVICE_NAME };
 export default HouseArrestService;
-

--- a/lib/installation-proxy/index.js
+++ b/lib/installation-proxy/index.js
@@ -1,12 +1,9 @@
 import _ from 'lodash';
+import { BaseServicePlist } from '../base-service';
 
 const INSTALLATION_PROXY_SERVICE_NAME = 'com.apple.mobile.installation_proxy';
 
-class InstallationProxyService {
-  constructor (plistService) {
-    this.plistService = plistService;
-  }
-
+class InstallationProxyService extends BaseServicePlist {
   /**
    * Install the application on the relative path on the phone
    * @param {string} path The path where the .app and .ipa is located at on the phone
@@ -20,7 +17,7 @@ class InstallationProxyService {
       ClientOptions: clientOptions
     };
 
-    this.plistService.sendPlist(request);
+    this._plistService.sendPlist(request);
     return await this._waitMessageCompletion(timeout);
   }
 
@@ -49,7 +46,7 @@ class InstallationProxyService {
       request.ClientOptions.ReturnAttributes = opts.returnAttributes;
     }
 
-    this.plistService.sendPlist(request);
+    this._plistService.sendPlist(request);
     const messages = await this._waitMessageCompletion();
     return messages.reduce((acc, message) => {
       if (!message.CurrentList) {
@@ -90,7 +87,7 @@ class InstallationProxyService {
       request.ClientOptions.ReturnAttributes = opts.returnAttributes;
     }
 
-    this.plistService.sendPlist(request);
+    this._plistService.sendPlist(request);
     const messages = await this._waitMessageCompletion();
     for (const message of messages) {
       if (message.LookupResult) {
@@ -111,7 +108,7 @@ class InstallationProxyService {
       ApplicationIdentifier: bundleId
     };
 
-    this.plistService.sendPlist(request);
+    this._plistService.sendPlist(request);
     return await this._waitMessageCompletion(timeout);
   }
 
@@ -119,7 +116,7 @@ class InstallationProxyService {
     let messages = [];
     // Just added for safety. This shouldn't happen
     for (let i = 0; i < Number.MAX_SAFE_INTEGER; i++) {
-      const data = await this.plistService.receivePlist(timeout);
+      const data = await this._plistService.receivePlist(timeout);
       messages.push(data);
       if (this._isFinished(data)) {
         return messages;
@@ -137,15 +134,7 @@ class InstallationProxyService {
     }
     return response.Status === 'Complete';
   }
-
-  /**
-   * Closes the underlying socket communicating with the phone
-   */
-  close () {
-    this.plistService.close();
-  }
 }
 
 export { InstallationProxyService, INSTALLATION_PROXY_SERVICE_NAME };
 export default InstallationProxyService;
-

--- a/lib/lockdown/index.js
+++ b/lib/lockdown/index.js
@@ -1,20 +1,18 @@
+import { BaseServicePlist } from '../base-service';
+
+
 const LOCKDOWN_PORT = 62078;
 const LABEL = 'usbmuxd';
 const PROTOCOL_VERSION = 2;
 
-class Lockdown {
-
-  constructor (plistService) {
-    this.plistService = plistService;
-  }
-
+class Lockdown extends BaseServicePlist {
   /**
    * Makes a query type request to lockdown
    * @param {number} [timeout=5000] the timeout of receiving a response from lockdownd
    * @returns {Object}
    */
   async queryType (timeout = 5000) {
-    const data = await this.plistService.sendPlistAndReceive({
+    const data = await this._plistService.sendPlistAndReceive({
       Label: LABEL,
       ProtocolVersion: PROTOCOL_VERSION,
       Request: 'QueryType'
@@ -34,7 +32,7 @@ class Lockdown {
    * @returns {Object}
    */
   async startSession (hostID, systemBUID, timeout = 5000) {
-    const data = await this.plistService.sendPlistAndReceive({
+    const data = await this._plistService.sendPlistAndReceive({
       Label: LABEL,
       ProtocolVersion: PROTOCOL_VERSION,
       Request: 'StartSession',
@@ -55,7 +53,7 @@ class Lockdown {
    * @param {Buffer} hostCertificate the certificate which can be retrieved from the pair record
    */
   enableSessionSSL (hostPrivateKey, hostCertificate) {
-    this.plistService.enableSessionSSL(hostPrivateKey, hostCertificate);
+    this._plistService.enableSessionSSL(hostPrivateKey, hostCertificate);
   }
 
   /**
@@ -78,7 +76,7 @@ class Lockdown {
       Request: 'GetValue'
     };
     Object.assign(plist, query);
-    const data = await this.plistService.sendPlistAndReceive(plist, timeout);
+    const data = await this._plistService.sendPlistAndReceive(plist, timeout);
     if (data.Request === 'GetValue' && data.Value) {
       return data.Value;
     } else {
@@ -93,7 +91,7 @@ class Lockdown {
    * @returns {Object}
    */
   async startService (serviceName, timeout = 5000) {
-    const data = await this.plistService.sendPlistAndReceive({
+    const data = await this._plistService.sendPlistAndReceive({
       Label: LABEL,
       ProtocolVersion: PROTOCOL_VERSION,
       Request: 'StartService',
@@ -105,12 +103,6 @@ class Lockdown {
     } else {
       return data;
     }
-  }
-  /**
-   * Closes the underlying socket communicating with the phone
-   */
-  close () {
-    this.plistService.close();
   }
 }
 

--- a/lib/notification-proxy/index.js
+++ b/lib/notification-proxy/index.js
@@ -89,6 +89,11 @@ class NotificationProxyService extends BaseServiceSocket {
       Command: 'Shutdown',
     });
   }
+
+  close () {
+    this.shutdown();
+    super.close();
+  }
 }
 
 export default NotificationProxyService;

--- a/lib/notification-proxy/index.js
+++ b/lib/notification-proxy/index.js
@@ -3,14 +3,17 @@ import PlistServiceDecoder from '../plist-service/transformer/plist-service-deco
 import LengthBasedSplitter from '../util/transformer/length-based-splitter';
 import { KB } from '../constants';
 import _ from 'lodash';
+import { BaseServiceSocket } from '../base-service';
+
 
 const NOTIFICATION_PROXY_SERVICE_NAME = 'com.apple.mobile.notification_proxy';
 const RELAY_NOTIFICATION = 'RelayNotification';
 const PROXY_DEATH = 'ProxyDeath';
 
-class NotificationProxyService {
+class NotificationProxyService extends BaseServiceSocket {
   constructor (socketClient) {
-    this._socketClient = socketClient;
+    super(socketClient);
+
     this._decoder = new PlistServiceDecoder();
     this._splitter = new LengthBasedSplitter(false, 16 * KB, 0, 4, 4);
     this._socketClient.pipe(this._splitter).pipe(this._decoder);
@@ -86,15 +89,6 @@ class NotificationProxyService {
       Command: 'Shutdown',
     });
   }
-
-  /**
-   * Closes the underlying socket communicating with the phone
-   */
-  close () {
-    this.shutdown();
-    this._socketClient.end();
-  }
-
 }
 
 export default NotificationProxyService;

--- a/lib/plist-service/index.js
+++ b/lib/plist-service/index.js
@@ -3,12 +3,15 @@ import { upgradeToSSL } from '../ssl-helper';
 import PlistServiceEncoder from './transformer/plist-service-encoder';
 import PlistServiceDecoder from './transformer/plist-service-decoder';
 import LengthBasedSplitter from '../util/transformer/length-based-splitter';
+import { BaseServiceSocket } from '../base-service';
+
 
 const CHECK_FREQ_MS = 50;
 
-class PlistService {
+class PlistService extends BaseServiceSocket {
   constructor (socketClient) {
-    this._socketClient = socketClient;
+    super(socketClient);
+
     this._decoder = new PlistServiceDecoder();
     this._splitter = new LengthBasedSplitter(false, 1000000, 0, 4, 4);
     this._socketClient.pipe(this._splitter).pipe(this._decoder);
@@ -62,10 +65,6 @@ class PlistService {
     this._socketClient = upgradeToSSL(this._socketClient, hostPrivateKey, hostCertificate);
     this._encoder.pipe(this._socketClient);
     this._socketClient.pipe(this._splitter).pipe(this._decoder);
-  }
-
-  close () {
-    this._socketClient.end();
   }
 }
 

--- a/lib/simulatelocation/index.js
+++ b/lib/simulatelocation/index.js
@@ -1,13 +1,12 @@
+import { BaseServiceSocket } from '../base-service';
+
+
 const SIMULATE_LOCATION_SERVICE_NAME = 'com.apple.dt.simulatelocation';
 
 const RESET_MESSAGE = Buffer.from([0, 0, 0, 1]);
 const SET_LOCATION_MESSAGE = Buffer.from([0, 0, 0, 0]);
 
-class SimulateLocationService {
-
-  constructor (socketClient) {
-    this._socketClient = socketClient;
-  }
+class SimulateLocationService extends BaseServiceSocket {
   /**
    * Reset the mock location to the phones original settings
    */
@@ -38,14 +37,6 @@ class SimulateLocationService {
     this._socketClient.write(long_length);
     this._socketClient.write(long);
   }
-
-  /**
-   * Closes the underlying socket communicating with the phone
-   */
-  close () {
-    this._socketClient.end();
-  }
-
 }
 
 export { SimulateLocationService, SIMULATE_LOCATION_SERVICE_NAME };

--- a/lib/syslog/index.js
+++ b/lib/syslog/index.js
@@ -1,15 +1,17 @@
 /* eslint-disable promise/prefer-await-to-callbacks */
 import SyslogDecoder from './transformer/syslog-decoder';
 import { KB } from '../constants';
+import { BaseServiceSocket } from '../base-service';
+
 
 //We just need to write any data to the client. It doesn't matter what we send
 const SYSLOG_SERVICE_NAME = 'com.apple.syslog_relay';
 const START_MESSAGE = 'start';
 
-class SyslogService {
-
+class SyslogService extends BaseServiceSocket {
   constructor (socketClient) {
-    this._socketClient = socketClient;
+    super(socketClient);
+
     this._decoder = new SyslogDecoder(5 * KB);
     this._socketClient.pipe(this._decoder);
 
@@ -28,14 +30,6 @@ class SyslogService {
     this._decoder.on('data', callback);
     this._socketClient.write(START_MESSAGE);
   }
-
-  /**
-   * Closes the underlying socket communicating with the phone
-   */
-  close () {
-    this._socketClient.end();
-  }
-
 }
 
 export { SyslogService, SYSLOG_SERVICE_NAME };

--- a/lib/usbmux/index.js
+++ b/lib/usbmux/index.js
@@ -8,6 +8,8 @@ import UsbmuxEncoder from './transformer/usbmux-encoder.js';
 import path from 'path';
 import PlistService from '../plist-service';
 import { Lockdown, LOCKDOWN_PORT } from '../lockdown';
+import { BaseServiceSocket } from '../base-service';
+
 
 const USBMUX_RESULT = {
   OK: 0,
@@ -33,10 +35,9 @@ function swap16 (val) {
   return ((val & 0xFF) << 8) | ((val >> 8) & 0xFF);
 }
 
-class Usbmux {
-
+class Usbmux extends BaseServiceSocket {
   constructor (socketClient = net.createConnection(DEFAULT_USBMUXD_SOCKET)) {
-    this._socketClient = socketClient;
+    super(socketClient);
 
     this._decoder = new UsbmuxDecoder();
     this._splitter = new LengthBasedSplitter(true, 1000000, 0, 4, 0);
@@ -184,12 +185,6 @@ class Usbmux {
     } else {
       throw new Error(`Unexpected data: ${JSON.stringify(data)}`);
     }
-  }
-  /**
-   * Closes the underlying socket communicating to the usbmuxd
-   */
-  close () {
-    this._socketClient.end();
   }
 }
 

--- a/lib/webinspector/index.js
+++ b/lib/webinspector/index.js
@@ -8,6 +8,7 @@ import _ from 'lodash';
 import { util } from 'appium-support';
 import { MB } from '../constants';
 import log from '../logger';
+import { BaseServiceSocket } from '../base-service';
 
 
 const WEB_INSPECTOR_SERVICE_NAME = 'com.apple.webinspector';
@@ -16,7 +17,7 @@ const PARTIAL_MESSAGE_SUPPORT_DEPRECATION_VERSION = 11;
 
 const MAX_FRAME_SIZE = 20000000;
 
-class WebInspectorService {
+class WebInspectorService extends BaseServiceSocket {
 
   /**
    * The main service for communication with the webinspectord
@@ -26,7 +27,8 @@ class WebInspectorService {
    * @param {*} socketClient The socket client where the communication will happen
    */
   constructor (majorOsVersion, isSimulator, verbose, socketClient) {
-    this._socketClient = socketClient;
+    super(socketClient);
+
     this._verbose = verbose;
 
     if (!isSimulator && majorOsVersion < PARTIAL_MESSAGE_SUPPORT_DEPRECATION_VERSION) {
@@ -84,13 +86,6 @@ class WebInspectorService {
       onData(data);
     });
   }
-  /**
-   * Closes the underlying socket communicating with the phone
-   */
-  close () {
-    this._socketClient.end();
-  }
-
 }
 
 export { WebInspectorService, WEB_INSPECTOR_SERVICE_NAME };


### PR DESCRIPTION
Recent changes have highlighted that there is a lot of shared code here. Get rid of that particular repetition.