### PR TITLE
fix: send chunks of data to web inspector

### DIFF
--- a/lib/plist-service/transformer/plist-service-encoder.js
+++ b/lib/plist-service/transformer/plist-service-encoder.js
@@ -2,25 +2,25 @@
 import Stream from 'stream';
 import { plist } from 'appium-support';
 
+
 const HEADER_LENGTH = 4;
 
 class PlistServiceEncoder extends Stream.Transform {
-
   constructor () {
     super({ objectMode: true });
   }
 
   _transform (data, encoding, callback) {
-    callback(null, this._encode(data));
+    this.push(this._encode(data), 'buffer');
+    callback();
   }
 
   _encode (data) {
-    let payloadBuffer = plist.createPlist(data, true);
+    let payloadBuffer = plist.createBinaryPlist(data);
     const headerBuffer = Buffer.alloc(HEADER_LENGTH);
     headerBuffer.writeUInt32BE(payloadBuffer.length, 0);
     return Buffer.concat([headerBuffer, payloadBuffer], headerBuffer.length + payloadBuffer.length);
   }
-
 }
 
 export { PlistServiceEncoder };

--- a/lib/services.js
+++ b/lib/services.js
@@ -21,7 +21,7 @@ async function startWebInspectorService (udid, opts = {}) {
   const osVersion = opts.osVersion || await getOSVersion(udid, opts.socket);
   const isSimulator = !!opts.isSimulator;
   const verbose = !!opts.verbose;
-  const verboseFull = !!opts.verboseFull;
+  const verboseHexDump = !!opts.verboseHexDump;
   const socketChunkSize = opts.socketChunkSize;
   const semverVersion = semver.coerce(osVersion);
   if (!semverVersion) {
@@ -33,7 +33,7 @@ async function startWebInspectorService (udid, opts = {}) {
     isSimulator,
     socketChunkSize,
     verbose,
-    verboseFull,
+    verboseHexDump,
     socketClient,
   });
 }

--- a/lib/services.js
+++ b/lib/services.js
@@ -28,7 +28,14 @@ async function startWebInspectorService (udid, opts = {}) {
     throw new Error(`Could not create a semver version out of '${osVersion}'`);
   }
   const socketClient = opts.socket || await startService(udid, WEB_INSPECTOR_SERVICE_NAME);
-  return new WebInspectorService(semverVersion.major, isSimulator, socketChunkSize, verbose, verboseFull, socketClient);
+  return new WebInspectorService({
+    majorOsVersion: semverVersion.major,
+    isSimulator,
+    socketChunkSize,
+    verbose,
+    verboseFull,
+    socketClient,
+  });
 }
 
 async function startInstallationProxyService (udid, opts = {}) {

--- a/lib/services.js
+++ b/lib/services.js
@@ -21,12 +21,14 @@ async function startWebInspectorService (udid, opts = {}) {
   const osVersion = opts.osVersion || await getOSVersion(udid, opts.socket);
   const isSimulator = !!opts.isSimulator;
   const verbose = !!opts.verbose;
+  const verboseFull = !!opts.verboseFull;
+  const socketChunkSize = opts.socketChunkSize;
   const semverVersion = semver.coerce(osVersion);
   if (!semverVersion) {
     throw new Error(`Could not create a semver version out of '${osVersion}'`);
   }
   const socketClient = opts.socket || await startService(udid, WEB_INSPECTOR_SERVICE_NAME);
-  return new WebInspectorService(semverVersion.major, isSimulator, verbose, socketClient);
+  return new WebInspectorService(semverVersion.major, isSimulator, socketChunkSize, verbose, verboseFull, socketClient);
 }
 
 async function startInstallationProxyService (udid, opts = {}) {

--- a/lib/util/transformer/stream-logger.js
+++ b/lib/util/transformer/stream-logger.js
@@ -11,7 +11,7 @@ const CHARACTERS_PER_LINE = 19;
 
 class StreamLogger extends Stream.Transform {
   constructor (direction, verbose = false) {
-    super();
+    super({ objectMode: true });
 
     this._direction = direction;
     this._verbose = verbose;

--- a/lib/util/transformer/stream-logger.js
+++ b/lib/util/transformer/stream-logger.js
@@ -27,6 +27,7 @@ class StreamLogger extends Stream.Transform {
         log.debug(`Error logging data: ${err.message}`);
       }
     }
+
     this.push(data);
     callback();
   }

--- a/lib/utilities.js
+++ b/lib/utilities.js
@@ -158,7 +158,7 @@ async function connectPort (udid, port, socket) {
   try {
     const device = await usbmux.findDevice(udid);
     if (!device) {
-      throw new Error(`Couldn't find the expected device ${udid}`);
+      throw new Error(`Could not find the expected device ${udid}`);
     }
     return await usbmux.connect(device.Properties.DeviceID, port);
   } catch (e) {

--- a/lib/webinspector/index.js
+++ b/lib/webinspector/index.js
@@ -55,7 +55,7 @@ class WebInspectorService extends BaseServiceSocket {
       this._decoder = new WebInspectorDecoder(MB);
       this._socketClient
         // log first, in case there is a problem in processing
-        .pipe(new StreamLogger(StreamLogger.RECEIVE, this._verbose))
+        .pipe(new StreamLogger(StreamLogger.RECEIVE, verboseFull))
         .pipe(new LengthBasedSplitter(false, MAX_FRAME_SIZE, 0, 4, 4))
         .pipe(new PlistServiceDecoder())
         .pipe(this._decoder);
@@ -64,19 +64,25 @@ class WebInspectorService extends BaseServiceSocket {
       this._encoder
         .pipe(new PlistServiceEncoder())
         .pipe(new StreamLogger(StreamLogger.SEND, verboseFull))
-        .pipe(new WebInspectorSocket(this._socketClient, {isSimulator, socketChunkSize}));
+        .pipe(isSimulator
+          ? this._socketClient
+          : new WebInspectorSocket(this._socketClient, {socketChunkSize})
+        );
     } else {
       this._decoder = new PlistServiceDecoder();
       this._socketClient
         // log first, in case there is a problem in processing
-        .pipe(new StreamLogger(StreamLogger.RECEIVE, this._verbose))
+        .pipe(new StreamLogger(StreamLogger.RECEIVE, verboseFull))
         .pipe(new LengthBasedSplitter(false, MAX_FRAME_SIZE, 0, 4, 4))
         .pipe(this._decoder);
 
       this._encoder = new PlistServiceEncoder();
       this._encoder
         .pipe(new StreamLogger(StreamLogger.SEND, verboseFull))
-        .pipe(new WebInspectorSocket(this._socketClient, {isSimulator, socketChunkSize}));
+        .pipe(isSimulator
+          ? this._socketClient
+          : new WebInspectorSocket(this._socketClient, {socketChunkSize})
+        );
     }
   }
 

--- a/lib/webinspector/index.js
+++ b/lib/webinspector/index.js
@@ -24,9 +24,13 @@ const MAX_FRAME_SIZE = 20000000;
  *
  * @property {number} majorOsVersion The major version of the os version
  * @property {boolean} isSimulator Whether the device is a simulator
- * @property {?number} socketChunkSize Size of the chunks to send to real device
- * @property {boolean} verbose Turn on logging of each message sent or received
- * @property {boolean} verboseHexDump Turn on logging of _all_ communication as hex dump
+ * @property {?number} socketChunkSize Size, in bytes of the chunks to send to
+ *                                     real device (only iOS 11+). Defaults to
+ *                                     5000 bytes.
+ * @property {boolean} verbose Turn on logging of each message sent or received.
+ *                             Defaults to false
+ * @property {boolean} verboseHexDump Turn on logging of _all_ communication as
+ *                                    hex dump. Defaults to false
  * @property {*} socketClient The socket client where the communication will happen
  */
 
@@ -39,10 +43,10 @@ class WebInspectorService extends BaseServiceSocket {
   constructor (opts = {}) {
     const {
       majorOsVersion,
-      isSimulator,
+      isSimulator = false,
       socketChunkSize,
-      verbose,
-      verboseHexDump,
+      verbose = false,
+      verboseHexDump = false,
       socketClient,
     } = opts;
 
@@ -57,24 +61,39 @@ class WebInspectorService extends BaseServiceSocket {
     }
   }
 
-  _initializeFullMessageSupport (isSimulator, verboseHexDump, socketChunkSize) {
+  /**
+   * Intializes the data flow for iOS 11+.
+   *
+   * @param {boolean} isSimulator - whether the device is a simulator or not
+   * @param {boolean} verbose - whether to print out the hex dump for communication
+   * @param {?number} socketChunkSize - size, in bytes, of the data to be sent
+   *                                    to real devices
+   */
+  _initializeFullMessageSupport (isSimulator, verbose, socketChunkSize = null) {
     this._decoder = new PlistServiceDecoder();
     this._socketClient
       // log first, in case there is a problem in processing
-      .pipe(new StreamLogger(StreamLogger.RECEIVE, verboseHexDump))
+      .pipe(new StreamLogger(StreamLogger.RECEIVE, verbose))
       .pipe(new LengthBasedSplitter(false, MAX_FRAME_SIZE, 0, 4, 4))
       .pipe(this._decoder);
 
     this._encoder = new PlistServiceEncoder();
     this._encoder
-      .pipe(new StreamLogger(StreamLogger.SEND, verboseHexDump))
+      .pipe(new StreamLogger(StreamLogger.SEND, verbose))
       .pipe(isSimulator
         ? this._socketClient
         : new WebInspectorSocket(this._socketClient, {socketChunkSize})
       );
   }
 
-  _initializePartialMessageSupport (isSimulator, verboseHexDump, socketChunkSize) {
+  /**
+   * Intializes the data flow for iOS < 11, where data is separated into partial
+   * messages before sending.
+   *
+   * @param {boolean} isSimulator - whether the device is a simulator or not
+   * @param {boolean} verbose - whether to print out the hex dump for communication
+   */
+  _initializePartialMessageSupport (isSimulator, verboseHexDump) {
     // 1MB as buffer for bulding webinspector full messages. We can increase the value if more buffer is needed
     this._decoder = new WebInspectorDecoder(MB);
     this._socketClient
@@ -88,10 +107,7 @@ class WebInspectorService extends BaseServiceSocket {
     this._encoder
       .pipe(new PlistServiceEncoder())
       .pipe(new StreamLogger(StreamLogger.SEND, verboseHexDump))
-      .pipe(isSimulator
-        ? this._socketClient
-        : new WebInspectorSocket(this._socketClient, {socketChunkSize})
-      );
+      .pipe(this._socketClient);
   }
 
   /**

--- a/lib/webinspector/index.js
+++ b/lib/webinspector/index.js
@@ -25,10 +25,12 @@ class WebInspectorService extends BaseServiceSocket {
    * The main service for communication with the webinspectord
    * @param {number} majorOsVersion The major version of the os version
    * @param {boolean} isSimulator Whether the device is a simulator
+   * @param {?number} socketChunkSize Size of the chunks to send to real device
    * @param {boolean} verbose Turn on logging of each message sent or received
+   * @param {boolean} verboseFull Turn on logging of _all_ communication as hex dump
    * @param {*} socketClient The socket client where the communication will happen
    */
-  constructor (majorOsVersion, isSimulator, verbose, socketClient) {
+  constructor (majorOsVersion, isSimulator, socketChunkSize, verbose, verboseFull, socketClient) {
     super(socketClient);
 
     this._verbose = verbose;
@@ -46,8 +48,8 @@ class WebInspectorService extends BaseServiceSocket {
       this._encoder = new WebInspectorEncoder();
       this._encoder
         .pipe(new PlistServiceEncoder())
-        .pipe(new StreamLogger(StreamLogger.SEND, this._verbose))
-        .pipe(new WebInspectorSocket(this._socketClient, {isSimulator}));
+        .pipe(new StreamLogger(StreamLogger.SEND, verboseFull))
+        .pipe(new WebInspectorSocket(this._socketClient, {isSimulator, socketChunkSize}));
     } else {
       this._decoder = new PlistServiceDecoder();
       this._socketClient
@@ -58,8 +60,8 @@ class WebInspectorService extends BaseServiceSocket {
 
       this._encoder = new PlistServiceEncoder();
       this._encoder
-        .pipe(new StreamLogger(StreamLogger.SEND, this._verbose))
-        .pipe(new WebInspectorSocket(this._socketClient, {isSimulator}));
+        .pipe(new StreamLogger(StreamLogger.SEND, verboseFull))
+        .pipe(new WebInspectorSocket(this._socketClient, {isSimulator, socketChunkSize}));
     }
   }
 

--- a/lib/webinspector/index.js
+++ b/lib/webinspector/index.js
@@ -19,18 +19,33 @@ const PARTIAL_MESSAGE_SUPPORT_DEPRECATION_VERSION = 11;
 
 const MAX_FRAME_SIZE = 20000000;
 
-class WebInspectorService extends BaseServiceSocket {
+/**
+ * @typedef {Object} WebInspectorServiceOptions
+ *
+ * @property {number} majorOsVersion The major version of the os version
+ * @property {boolean} isSimulator Whether the device is a simulator
+ * @property {?number} socketChunkSize Size of the chunks to send to real device
+ * @property {boolean} verbose Turn on logging of each message sent or received
+ * @property {boolean} verboseFull Turn on logging of _all_ communication as hex dump
+ * @property {*} socketClient The socket client where the communication will happen
+ */
 
+class WebInspectorService extends BaseServiceSocket {
   /**
    * The main service for communication with the webinspectord
-   * @param {number} majorOsVersion The major version of the os version
-   * @param {boolean} isSimulator Whether the device is a simulator
-   * @param {?number} socketChunkSize Size of the chunks to send to real device
-   * @param {boolean} verbose Turn on logging of each message sent or received
-   * @param {boolean} verboseFull Turn on logging of _all_ communication as hex dump
-   * @param {*} socketClient The socket client where the communication will happen
+   *
+   * @param {WebInspectorServiceOptions}
    */
-  constructor (majorOsVersion, isSimulator, socketChunkSize, verbose, verboseFull, socketClient) {
+  constructor (opts = {}) {
+    const {
+      majorOsVersion,
+      isSimulator,
+      socketChunkSize,
+      verbose,
+      verboseFull,
+      socketClient,
+    } = opts;
+
     super(socketClient);
 
     this._verbose = verbose;

--- a/lib/webinspector/index.js
+++ b/lib/webinspector/index.js
@@ -1,6 +1,7 @@
 /* eslint-disable promise/prefer-await-to-callbacks */
 import WebInspectorDecoder from './transformer/webinspector-decoder';
 import WebInspectorEncoder from './transformer/webinspector-encoder';
+import WebInspectorSocket from './transformer/webinspector-socket';
 import PlistServiceDecoder from '../plist-service/transformer/plist-service-decoder';
 import PlistServiceEncoder from '../plist-service/transformer/plist-service-encoder';
 import LengthBasedSplitter from '../util/transformer/length-based-splitter';
@@ -58,7 +59,7 @@ class WebInspectorService extends BaseServiceSocket {
       this._encoder = new PlistServiceEncoder();
       this._encoder
         .pipe(new StreamLogger(StreamLogger.SEND, this._verbose))
-        .pipe(this._socketClient);
+        .pipe(new WebInspectorSocket(this._socketClient));
     }
   }
 
@@ -71,16 +72,13 @@ class WebInspectorService extends BaseServiceSocket {
     if (_.isNil(rpcObject)) {
       throw new Error('Cannot send a null object');
     }
+
     if (this._verbose) {
       log.debug('Sending message to Web Inspector:');
       log.debug(util.jsonStringify(rpcObject));
     }
-    this._encoder.write(rpcObject);
 
-    // write an empty message, which on real devices ensures the actual message
-    // gets sent to the device. without this it will periodically hang with
-    // nothing sent
-    this._encoder.write('');
+    this._encoder.write(rpcObject);
   }
 
   /** The callback function which will be called during message listening

--- a/lib/webinspector/index.js
+++ b/lib/webinspector/index.js
@@ -47,7 +47,7 @@ class WebInspectorService extends BaseServiceSocket {
       this._encoder
         .pipe(new PlistServiceEncoder())
         .pipe(new StreamLogger(StreamLogger.SEND, this._verbose))
-        .pipe(this._socketClient);
+        .pipe(new WebInspectorSocket(this._socketClient, {isSimulator}));
     } else {
       this._decoder = new PlistServiceDecoder();
       this._socketClient
@@ -59,7 +59,7 @@ class WebInspectorService extends BaseServiceSocket {
       this._encoder = new PlistServiceEncoder();
       this._encoder
         .pipe(new StreamLogger(StreamLogger.SEND, this._verbose))
-        .pipe(new WebInspectorSocket(this._socketClient));
+        .pipe(new WebInspectorSocket(this._socketClient, {isSimulator}));
     }
   }
 

--- a/lib/webinspector/index.js
+++ b/lib/webinspector/index.js
@@ -26,7 +26,7 @@ const MAX_FRAME_SIZE = 20000000;
  * @property {boolean} isSimulator Whether the device is a simulator
  * @property {?number} socketChunkSize Size of the chunks to send to real device
  * @property {boolean} verbose Turn on logging of each message sent or received
- * @property {boolean} verboseFull Turn on logging of _all_ communication as hex dump
+ * @property {boolean} verboseHexDump Turn on logging of _all_ communication as hex dump
  * @property {*} socketClient The socket client where the communication will happen
  */
 
@@ -42,7 +42,7 @@ class WebInspectorService extends BaseServiceSocket {
       isSimulator,
       socketChunkSize,
       verbose,
-      verboseFull,
+      verboseHexDump,
       socketClient,
     } = opts;
 
@@ -51,39 +51,47 @@ class WebInspectorService extends BaseServiceSocket {
     this._verbose = verbose;
 
     if (!isSimulator && majorOsVersion < PARTIAL_MESSAGE_SUPPORT_DEPRECATION_VERSION) {
-      // 1MB as buffer for bulding webinspector full messages. We can increase the value if more buffer is needed
-      this._decoder = new WebInspectorDecoder(MB);
-      this._socketClient
-        // log first, in case there is a problem in processing
-        .pipe(new StreamLogger(StreamLogger.RECEIVE, verboseFull))
-        .pipe(new LengthBasedSplitter(false, MAX_FRAME_SIZE, 0, 4, 4))
-        .pipe(new PlistServiceDecoder())
-        .pipe(this._decoder);
-
-      this._encoder = new WebInspectorEncoder();
-      this._encoder
-        .pipe(new PlistServiceEncoder())
-        .pipe(new StreamLogger(StreamLogger.SEND, verboseFull))
-        .pipe(isSimulator
-          ? this._socketClient
-          : new WebInspectorSocket(this._socketClient, {socketChunkSize})
-        );
+      this._initializePartialMessageSupport(isSimulator, verboseHexDump, socketChunkSize);
     } else {
-      this._decoder = new PlistServiceDecoder();
-      this._socketClient
-        // log first, in case there is a problem in processing
-        .pipe(new StreamLogger(StreamLogger.RECEIVE, verboseFull))
-        .pipe(new LengthBasedSplitter(false, MAX_FRAME_SIZE, 0, 4, 4))
-        .pipe(this._decoder);
-
-      this._encoder = new PlistServiceEncoder();
-      this._encoder
-        .pipe(new StreamLogger(StreamLogger.SEND, verboseFull))
-        .pipe(isSimulator
-          ? this._socketClient
-          : new WebInspectorSocket(this._socketClient, {socketChunkSize})
-        );
+      this._initializeFullMessageSupport(isSimulator, verboseHexDump, socketChunkSize);
     }
+  }
+
+  _initializeFullMessageSupport (isSimulator, verboseHexDump, socketChunkSize) {
+    this._decoder = new PlistServiceDecoder();
+    this._socketClient
+      // log first, in case there is a problem in processing
+      .pipe(new StreamLogger(StreamLogger.RECEIVE, verboseHexDump))
+      .pipe(new LengthBasedSplitter(false, MAX_FRAME_SIZE, 0, 4, 4))
+      .pipe(this._decoder);
+
+    this._encoder = new PlistServiceEncoder();
+    this._encoder
+      .pipe(new StreamLogger(StreamLogger.SEND, verboseHexDump))
+      .pipe(isSimulator
+        ? this._socketClient
+        : new WebInspectorSocket(this._socketClient, {socketChunkSize})
+      );
+  }
+
+  _initializePartialMessageSupport (isSimulator, verboseHexDump, socketChunkSize) {
+    // 1MB as buffer for bulding webinspector full messages. We can increase the value if more buffer is needed
+    this._decoder = new WebInspectorDecoder(MB);
+    this._socketClient
+      // log first, in case there is a problem in processing
+      .pipe(new StreamLogger(StreamLogger.RECEIVE, verboseHexDump))
+      .pipe(new LengthBasedSplitter(false, MAX_FRAME_SIZE, 0, 4, 4))
+      .pipe(new PlistServiceDecoder())
+      .pipe(this._decoder);
+
+    this._encoder = new WebInspectorEncoder();
+    this._encoder
+      .pipe(new PlistServiceEncoder())
+      .pipe(new StreamLogger(StreamLogger.SEND, verboseHexDump))
+      .pipe(isSimulator
+        ? this._socketClient
+        : new WebInspectorSocket(this._socketClient, {socketChunkSize})
+      );
   }
 
   /**

--- a/lib/webinspector/transformer/webinspector-decoder.js
+++ b/lib/webinspector/transformer/webinspector-decoder.js
@@ -4,7 +4,6 @@ import { plist } from 'appium-support';
 
 
 class WebInspectorDecoder extends Stream.Transform {
-
   constructor (maxLength) {
     super({ objectMode: true });
     this._frameBufferIndex = 0;
@@ -38,7 +37,6 @@ class WebInspectorDecoder extends Stream.Transform {
   _resetBuffers () {
     this._frameBufferIndex = 0;
   }
-
 }
 
 export { WebInspectorDecoder };

--- a/lib/webinspector/transformer/webinspector-socket.js
+++ b/lib/webinspector/transformer/webinspector-socket.js
@@ -3,7 +3,7 @@ import Stream from 'stream';
 import _ from 'lodash';
 
 
-const CHUNK_SIZE = 1000;
+const CHUNK_SIZE = 5000;
 
 class WebInspectorSocket extends Stream.Transform {
   constructor (socketClient, opts = {}) {
@@ -14,16 +14,17 @@ class WebInspectorSocket extends Stream.Transform {
     this._socketClient.setNoDelay(true);
     this._socketClient.setKeepAlive(true);
 
-    this.isSimulator = !!opts.isSimulator;
+    this._isSimulator = !!opts.isSimulator;
+    this._socketChunkSize = opts.socketChunkSize || CHUNK_SIZE;
   }
 
   _transform (data, encoding, callback) {
-    if (!this.isSimulator && (_.isBuffer(data) || _.isString(data))) {
-      let start = 0, end = CHUNK_SIZE;
+    if (!this._isSimulator && (_.isBuffer(data) || _.isString(data))) {
+      let start = 0, end = this._socketChunkSize;
       while (start < data.length) {
         const chunkBuffer = data.slice(start, end);
         start = end;
-        end = end + 1000;
+        end = end + this._socketChunkSize;
         this._socketClient.write(chunkBuffer, encoding);
       }
     } else {

--- a/lib/webinspector/transformer/webinspector-socket.js
+++ b/lib/webinspector/transformer/webinspector-socket.js
@@ -10,16 +10,15 @@ class WebInspectorSocket extends Stream.Transform {
     super({ objectMode: true });
 
     this._socketClient = socketClient;
-
     this._socketClient.setNoDelay(true);
     this._socketClient.setKeepAlive(true);
 
-    this._isSimulator = !!opts.isSimulator;
     this._socketChunkSize = opts.socketChunkSize || CHUNK_SIZE;
   }
 
   _transform (data, encoding, callback) {
-    if (!this._isSimulator && (_.isBuffer(data) || _.isString(data))) {
+    this._socketClient.cork();
+    if (_.isBuffer(data) || _.isString(data)) {
       let start = 0, end = this._socketChunkSize;
       while (start < data.length) {
         const chunkBuffer = data.slice(start, end);
@@ -30,6 +29,8 @@ class WebInspectorSocket extends Stream.Transform {
     } else {
       this._socketClient.write(data, encoding);
     }
+    this._socketClient.uncork();
+
     this.push(data, encoding);
     callback();
   }

--- a/lib/webinspector/transformer/webinspector-socket.js
+++ b/lib/webinspector/transformer/webinspector-socket.js
@@ -6,17 +6,19 @@ import _ from 'lodash';
 const CHUNK_SIZE = 1000;
 
 class WebInspectorSocket extends Stream.Transform {
-  constructor (socketClient) {
+  constructor (socketClient, opts = {}) {
     super({ objectMode: true });
 
     this._socketClient = socketClient;
 
     this._socketClient.setNoDelay(true);
     this._socketClient.setKeepAlive(true);
+
+    this.isSimulator = !!opts.isSimulator;
   }
 
   _transform (data, encoding, callback) {
-    if (_.isBuffer(data) || _.isString(data)) {
+    if (!this.isSimulator && (_.isBuffer(data) || _.isString(data))) {
       let start = 0, end = CHUNK_SIZE;
       while (start < data.length) {
         const chunkBuffer = data.slice(start, end);

--- a/lib/webinspector/transformer/webinspector-socket.js
+++ b/lib/webinspector/transformer/webinspector-socket.js
@@ -3,7 +3,7 @@ import Stream from 'stream';
 import _ from 'lodash';
 
 
-const CHUNK_SIZE = 5000;
+const CHUNK_SIZE = 5000; // bytes
 
 class WebInspectorSocket extends Stream.Transform {
   constructor (socketClient, opts = {}) {
@@ -16,20 +16,34 @@ class WebInspectorSocket extends Stream.Transform {
     this._socketChunkSize = opts.socketChunkSize || CHUNK_SIZE;
   }
 
-  _transform (data, encoding, callback) {
+  /**
+   * Send data to the socket client, making sure the socket is flushed after
+   * each call
+   *
+   * @param {string|buffer|object} data - the data to send over the socket
+   * @param {string} encoding - the type of data being sent
+   */
+  _socketSend (data, encoding) {
     this._socketClient.cork();
+    try {
+      this._socketClient.write(data, encoding);
+    } finally {
+      this._socketClient.uncork();
+    }
+  }
+
+  _transform (data, encoding, callback) {
     if (_.isBuffer(data) || _.isString(data)) {
       let start = 0, end = this._socketChunkSize;
       while (start < data.length) {
         const chunkBuffer = data.slice(start, end);
         start = end;
-        end = end + this._socketChunkSize;
-        this._socketClient.write(chunkBuffer, encoding);
+        end += this._socketChunkSize;
+        this._socketSend(chunkBuffer, encoding);
       }
     } else {
-      this._socketClient.write(data, encoding);
+      this._socketSend(data, encoding);
     }
-    this._socketClient.uncork();
 
     this.push(data, encoding);
     callback();

--- a/lib/webinspector/transformer/webinspector-socket.js
+++ b/lib/webinspector/transformer/webinspector-socket.js
@@ -1,0 +1,36 @@
+/* eslint-disable promise/prefer-await-to-callbacks */
+import Stream from 'stream';
+import _ from 'lodash';
+
+
+const CHUNK_SIZE = 1000;
+
+class WebInspectorSocket extends Stream.Transform {
+  constructor (socketClient) {
+    super({ objectMode: true });
+
+    this._socketClient = socketClient;
+
+    this._socketClient.setNoDelay(true);
+    this._socketClient.setKeepAlive(true);
+  }
+
+  _transform (data, encoding, callback) {
+    if (_.isBuffer(data) || _.isString(data)) {
+      let start = 0, end = CHUNK_SIZE;
+      while (start < data.length) {
+        const chunkBuffer = data.slice(start, end);
+        start = end;
+        end = end + 1000;
+        this._socketClient.write(chunkBuffer, encoding);
+      }
+    } else {
+      this._socketClient.write(data, encoding);
+    }
+    this.push(data, encoding);
+    callback();
+  }
+}
+
+export { WebInspectorSocket };
+export default WebInspectorSocket;

--- a/test/webinspector/webinspector-service-specs.js
+++ b/test/webinspector/webinspector-service-specs.js
@@ -24,7 +24,7 @@ describe('webinspector', function () {
   it('should receive webinspector WIRFinalMessageKey messages back', async function () {
     const version = semver.coerce('10.2.0');
     ({server, socket} = await getServerWithFixtures(fixtures.WEBINSPECTOR_PARTIAL_MESSAGES));
-    webInspectorService = new WebInspectorService(version.major, false, false, socket);
+    webInspectorService = new WebInspectorService(version.major, true, undefined, false, false, socket);
     let obj = {__argument: {WIRConnectionIdentifierKey: '990cc163-d8b2-4d22-8d1c-644e100a5a07'}, __selector: '_rpc_reportIdentifier:'};
     webInspectorService.sendMessage(obj);
     await new B((resolve) => {
@@ -34,7 +34,7 @@ describe('webinspector', function () {
   it('should receive webinspector ios 11 and above messages back', async function () {
     const version = semver.coerce('12.2.0');
     ({server, socket} = await getServerWithFixtures(fixtures.WEBINSPECTOR_MESSAGES));
-    webInspectorService = new WebInspectorService(version.major, false, false, socket);
+    webInspectorService = new WebInspectorService(version.major, true, undefined, false, false, socket);
     let obj = {__argument: {WIRConnectionIdentifierKey: '990cc163-d8b2-4d22-8d1c-644e100a5a07'}, __selector: '_rpc_reportIdentifier:'};
     webInspectorService.sendMessage(obj);
     await new B((resolve) => {

--- a/test/webinspector/webinspector-service-specs.js
+++ b/test/webinspector/webinspector-service-specs.js
@@ -29,7 +29,7 @@ describe('webinspector', function () {
       isSimulator: true,
       socketChunkSize: undefined,
       verbose: true,
-      verboseFull: false,
+      verboseHexDump: false,
       socketClient: socket,
     });
     let obj = {__argument: {WIRConnectionIdentifierKey: '990cc163-d8b2-4d22-8d1c-644e100a5a07'}, __selector: '_rpc_reportIdentifier:'};
@@ -46,7 +46,7 @@ describe('webinspector', function () {
       isSimulator: true,
       socketChunkSize: undefined,
       verbose: true,
-      verboseFull: false,
+      verboseHexDump: false,
       socketClient: socket,
     });
     let obj = {__argument: {WIRConnectionIdentifierKey: '990cc163-d8b2-4d22-8d1c-644e100a5a07'}, __selector: '_rpc_reportIdentifier:'};

--- a/test/webinspector/webinspector-service-specs.js
+++ b/test/webinspector/webinspector-service-specs.js
@@ -24,7 +24,14 @@ describe('webinspector', function () {
   it('should receive webinspector WIRFinalMessageKey messages back', async function () {
     const version = semver.coerce('10.2.0');
     ({server, socket} = await getServerWithFixtures(fixtures.WEBINSPECTOR_PARTIAL_MESSAGES));
-    webInspectorService = new WebInspectorService(version.major, true, undefined, false, false, socket);
+    webInspectorService = new WebInspectorService({
+      majorOsVersion: version.major,
+      isSimulator: true,
+      socketChunkSize: undefined,
+      verbose: true,
+      verboseFull: false,
+      socketClient: socket,
+    });
     let obj = {__argument: {WIRConnectionIdentifierKey: '990cc163-d8b2-4d22-8d1c-644e100a5a07'}, __selector: '_rpc_reportIdentifier:'};
     webInspectorService.sendMessage(obj);
     await new B((resolve) => {
@@ -34,7 +41,14 @@ describe('webinspector', function () {
   it('should receive webinspector ios 11 and above messages back', async function () {
     const version = semver.coerce('12.2.0');
     ({server, socket} = await getServerWithFixtures(fixtures.WEBINSPECTOR_MESSAGES));
-    webInspectorService = new WebInspectorService(version.major, true, undefined, false, false, socket);
+    webInspectorService = new WebInspectorService({
+      majorOsVersion: version.major,
+      isSimulator: true,
+      socketChunkSize: undefined,
+      verbose: true,
+      verboseFull: false,
+      socketClient: socket,
+    });
     let obj = {__argument: {WIRConnectionIdentifierKey: '990cc163-d8b2-4d22-8d1c-644e100a5a07'}, __selector: '_rpc_reportIdentifier:'};
     webInspectorService.sendMessage(obj);
     await new B((resolve) => {


### PR DESCRIPTION
On real devices larger blocks of data sent to the Web Inspector get stuck. Sending them in as chunks of data seems to fix the problem. The chunk size can be changed from 5000 bytes default, using the `socketChunkSize` option to the service (and service creator).

This also adds a `verboseHexDump` option in order to independently control the plain text logging of individual plists and the hex dump of all communication back and forth.