### PR TITLE
refactor: clean up afc code

### DIFF
--- a/lib/afc/index.js
+++ b/lib/afc/index.js
@@ -13,7 +13,7 @@ import { BaseServiceSocket } from '../base-service';
 
 const AFC_SERVICE_NAME = 'com.apple.afc';
 
-const NULL_DELIMETER_CODE = 0x00;
+const NULL_DELIMITER_CODE = 0x00;
 const IGNORED_PATHS = ['.', '..'];
 
 class AfcService extends BaseServiceSocket {
@@ -34,7 +34,7 @@ class AfcService extends BaseServiceSocket {
   }
 
   _handleData (data) {
-    const cb = this._responseCallbacks[data.packetNumber] || _.noop();
+    const cb = this._responseCallbacks[data.packetNumber] || _.noop;
     cb(data);
   }
 
@@ -265,7 +265,7 @@ class AfcService extends BaseServiceSocket {
       throw new Error(`Unexpected response ${operationCode(res.opCode)}`);
     }
     if (_.isEmpty(res.headerPayload)) {
-      throw new Error('Header payload cant be empty for a status response');
+      throw new Error('Header payload cannot be empty for a status response');
     }
     if (res.headerPayload[0] !== Errors.SUCCESS) {
       throw new Error(`Unexpected response ${errorCode(res.headerPayload[0])}`);
@@ -276,7 +276,7 @@ class AfcService extends BaseServiceSocket {
     const items = [];
     let start = 0;
     for (let end = 0; end < buffer.length; end++) {
-      if (buffer[end] !== NULL_DELIMETER_CODE) {
+      if (buffer[end] !== NULL_DELIMITER_CODE) {
         continue;
       }
       const item = buffer.toString('utf8', start, end);
@@ -292,7 +292,7 @@ class AfcService extends BaseServiceSocket {
     let start = 0;
     let currentKey;
     for (let end = 0; end < buffer.length; end++) {
-      if (buffer[end] !== NULL_DELIMETER_CODE) {
+      if (buffer[end] !== NULL_DELIMITER_CODE) {
         continue;
       }
       const item = buffer.toString('utf8', start, end);
@@ -314,15 +314,17 @@ class AfcService extends BaseServiceSocket {
   _createPacketPromise (message, timeout = 10000) {
     const packetNumber = this._packetNumber++;
     const response = new B((resolve, reject) => {
-      this._responseCallbacks[packetNumber] = (data) => resolve(data);
-      setTimeout(() => reject(new Error(`Cound't finish the operation "${message}". Failed to receive any data within the timeout: ${timeout}`)), timeout);
+      this._responseCallbacks[packetNumber] = resolve;
+      setTimeout(function () {
+        reject(new Error(`Could not finish the operation '${message}'. Failed to receive any data within the timeout: ${timeout}`));
+      }, timeout);
     });
-    return { packetNumber, response };
+    return {packetNumber, response};
   }
 }
 
 class FileInfo {
-  constructor ({ st_size, st_blocks, st_nlink, st_ifmt, st_mtime, st_birthtime }) {
+  constructor ({st_size, st_blocks, st_nlink, st_ifmt, st_mtime, st_birthtime}) {
     this.size = parseInt(st_size, 10);
     this.blocks = parseInt(st_blocks, 10);
     this.nlink = parseInt(st_nlink, 10);

--- a/lib/afc/index.js
+++ b/lib/afc/index.js
@@ -316,7 +316,7 @@ class AfcService extends BaseServiceSocket {
     const response = new B((resolve, reject) => {
       this._responseCallbacks[packetNumber] = resolve;
       setTimeout(function () {
-        reject(new Error(`Could not finish the operation '${message}'. Failed to receive any data within the timeout: ${timeout}`));
+        reject(new Error(`Could not finish the operation '${message}'. Failed to receive any data within the ${timeout}ms timeout`));
       }, timeout);
     });
     return {packetNumber, response};

--- a/lib/afc/protocol.js
+++ b/lib/afc/protocol.js
@@ -97,4 +97,8 @@ const FileModes = {
   'a+': 0x00000006, // O_RDWR   | O_APPEND | O_CREAT
 };
 
-export {MAGIC_NUMBER, AFC_PACKET_HEADER_SIZE, Operations, operationCode, Errors, errorCode, FileModes};
+export {
+  MAGIC_NUMBER, AFC_PACKET_HEADER_SIZE,
+  Operations, operationCode,
+  Errors, errorCode, FileModes,
+};

--- a/lib/usbmux/index.js
+++ b/lib/usbmux/index.js
@@ -52,7 +52,7 @@ class Usbmux extends BaseServiceSocket {
   }
 
   _handleData (data) {
-    const cb = this._responseCallbacks[data.header.tag] || _.noop();
+    const cb = this._responseCallbacks[data.header.tag] || _.noop;
     cb(data); // eslint-disable-line promise/prefer-await-to-callbacks
   }
 


### PR DESCRIPTION
While exploring the code, I did some cleanup. The only substantive change is moving from `_.noop()` (which is `undefined`) to `_.noop` (which is a null function) for the default callback on the `usbmux` and `afc` services.