### PR TITLE
fix: Change async callbacks to "classic" promise calls

### DIFF
--- a/lib/afc/streams.js
+++ b/lib/afc/streams.js
@@ -31,21 +31,21 @@ class AfcReadableFileStream extends stream.Readable {
       });
   }
 
-  _destroy (err, cb) {
+  _destroy (err, done) {
     if (this._destroyed) {
       return;
     }
     this._destroyed = true;
     this.push(null);
     this._afcService.closeFileHandle(this._fileHandle)
-      .then(() => cb(err))
+      .then(() => done(err))
       .catch((e) => {
         if (err) {
           log.debug(e);
         } else {
           err = e;
         }
-        cb(err);
+        done(err);
       });
   }
 }
@@ -60,31 +60,31 @@ class AfcWritableFileStream extends stream.Writable {
     this._destroyed = false;
   }
 
-  _write (chunk, encoding, cb) {
+  _write (chunk, encoding, next) {
     this._afcService.writeFile(this._fileHandle, chunk)
-      .then(cb)
+      .then(() => next())
       .catch((e) => {
         if (this._autoDestroy) {
           this.destroy(e);
         }
-        cb(e);
+        next(e);
       });
   }
 
-  _destroy (err, cb) {
+  _destroy (err, done) {
     if (this._destroyed) {
       return;
     }
     this._destroyed = true;
     this._afcService.closeFileHandle(this._fileHandle)
-      .then(() => cb(err))
+      .then(() => done(err))
       .catch((e) => {
         if (err) {
           log.debug(e);
         } else {
           err = e;
         }
-        cb(err);
+        done(err);
       });
   }
 }

--- a/lib/afc/streams.js
+++ b/lib/afc/streams.js
@@ -66,9 +66,8 @@ class AfcWritableFileStream extends stream.Writable {
       .catch((e) => {
         if (this._autoDestroy) {
           this.destroy(e);
-        } else {
-          cb(e);
         }
+        cb(e);
       });
   }
 

--- a/lib/afc/streams.js
+++ b/lib/afc/streams.js
@@ -3,6 +3,7 @@
 /* eslint-disable promise/prefer-await-to-callbacks */
 import stream from 'stream';
 import _ from 'lodash';
+import log from '../logger';
 
 class AfcReadableFileStream extends stream.Readable {
 
@@ -38,7 +39,11 @@ class AfcReadableFileStream extends stream.Readable {
     this.push(null);
     this._afcService.closeFileHandle(this._fileHandle)
       .catch((e) => {
-        err = err || e;
+        if (err) {
+          log.debug(e);
+        } else {
+          err = e;
+        }
       })
       .finally(() => cb(err));
   }
@@ -56,7 +61,7 @@ class AfcWritableFileStream extends stream.Writable {
 
   _write (chunk, encoding, cb) {
     this._afcService.writeFile(this._fileHandle, chunk)
-      .then(() => cb())
+      .then(cb)
       .catch((e) => {
         if (this._autoDestroy) {
           this.destroy(e);
@@ -73,7 +78,11 @@ class AfcWritableFileStream extends stream.Writable {
     this._destroyed = true;
     this._afcService.closeFileHandle(this._fileHandle)
       .catch((e) => {
-        err = err || e;
+        if (err) {
+          log.debug(e);
+        } else {
+          err = e;
+        }
       })
       .finally(() => cb(err));
   }

--- a/lib/afc/streams.js
+++ b/lib/afc/streams.js
@@ -38,14 +38,15 @@ class AfcReadableFileStream extends stream.Readable {
     this._destroyed = true;
     this.push(null);
     this._afcService.closeFileHandle(this._fileHandle)
+      .then(() => cb(err))
       .catch((e) => {
         if (err) {
           log.debug(e);
         } else {
           err = e;
         }
-      })
-      .finally(() => cb(err));
+        cb(err);
+      });
   }
 }
 
@@ -77,14 +78,15 @@ class AfcWritableFileStream extends stream.Writable {
     }
     this._destroyed = true;
     this._afcService.closeFileHandle(this._fileHandle)
+      .then(() => cb(err))
       .catch((e) => {
         if (err) {
           log.debug(e);
         } else {
           err = e;
         }
-      })
-      .finally(() => cb(err));
+        cb(err);
+      });
   }
 }
 

--- a/lib/afc/streams.js
+++ b/lib/afc/streams.js
@@ -1,3 +1,5 @@
+/* eslint-disable promise/catch-or-return */
+/* eslint-disable promise/prefer-await-to-then */
 /* eslint-disable promise/prefer-await-to-callbacks */
 import stream from 'stream';
 import _ from 'lodash';
@@ -12,40 +14,33 @@ class AfcReadableFileStream extends stream.Readable {
     this._destroyed = false;
   }
 
-  async _read (size) {
-    try {
-      const data = await this._afcService.readFile(this._fileHandle, size);
-
-      if (this._destroyed) {
-        return;
-      }
-
-      if (_.isEmpty(data)) {
-        return this.push(null);
-      }
-
-      this.push(data);
-    } catch (e) {
-      if (this._autoDestroy) {
-        this.destroy(e);
-      } else {
-        this.emit('error', e);
-      }
-    }
+  _read (size) {
+    this._afcService.readFile(this._fileHandle, size)
+      .then((data) => {
+        if (!this._destroyed) {
+          this.push(_.isEmpty(data) ? null : data);
+        }
+      })
+      .catch((e) => {
+        if (this._autoDestroy) {
+          this.destroy(e);
+        } else {
+          this.emit('error', e);
+        }
+      });
   }
 
-  async _destroy (err, cb) {
+  _destroy (err, cb) {
     if (this._destroyed) {
       return;
     }
     this._destroyed = true;
     this.push(null);
-    try {
-      await this._afcService.closeFileHandle(this._fileHandle);
-    } catch (e) {
-      err = err || e;
-    }
-    cb(err);
+    this._afcService.closeFileHandle(this._fileHandle)
+      .catch((e) => {
+        err = err || e;
+      })
+      .finally(() => cb(err));
   }
 }
 
@@ -59,29 +54,28 @@ class AfcWritableFileStream extends stream.Writable {
     this._destroyed = false;
   }
 
-  async _write (chunk, encoding, cb) {
-    try {
-      await this._afcService.writeFile(this._fileHandle, chunk);
-      cb();
-    } catch (e) {
-      if (this._autoDestroy) {
-        this.destroy(e);
-      }
-      cb(e);
-    }
+  _write (chunk, encoding, cb) {
+    this._afcService.writeFile(this._fileHandle, chunk)
+      .then(() => cb())
+      .catch((e) => {
+        if (this._autoDestroy) {
+          this.destroy(e);
+        } else {
+          cb(e);
+        }
+      });
   }
 
-  async _destroy (err, cb) {
+  _destroy (err, cb) {
     if (this._destroyed) {
       return;
     }
     this._destroyed = true;
-    try {
-      await this._afcService.closeFileHandle(this._fileHandle);
-    } catch (e) {
-      err = err || e;
-    }
-    cb(err);
+    this._afcService.closeFileHandle(this._fileHandle)
+      .catch((e) => {
+        err = err || e;
+      })
+      .finally(() => cb(err));
   }
 }
 


### PR DESCRIPTION
Related to https://github.com/appium/appium/issues/13757#issuecomment-570640266

Internally these callbacks are not awaited, which means any errors there cause unhandled exceptions