### PR TITLE
fix: not sending blank messages to web inspector for iOS 10.x

### DIFF
--- a/lib/webinspector/index.js
+++ b/lib/webinspector/index.js
@@ -63,6 +63,7 @@ class WebInspectorService extends BaseServiceSocket {
 
     this._verbose = verbose;
     this._isSimulator = isSimulator;
+    this._majorOsVersion = majorOsVersion;
 
     if (!isSimulator && majorOsVersion < PARTIAL_MESSAGE_SUPPORT_DEPRECATION_VERSION) {
       this._initializePartialMessageSupport(verboseHexDump);
@@ -133,7 +134,8 @@ class WebInspectorService extends BaseServiceSocket {
     // write an empty message, which on real devices ensures the actual message
     // gets sent to the device. without this it will periodically hang with
     // nothing sent
-    if (!this._isSimulator) {
+    // however, this causes webinspectord to crash on devices running iOS 10
+    if (!this._isSimulator && this._majorOsVersion >= PARTIAL_MESSAGE_SUPPORT_DEPRECATION_VERSION) {
       this._encoder.write(' ');
     }
   }


### PR DESCRIPTION
Apparently webinspectord on iOS 10.x can't handle blank messages (sending such messages causes it to crash).

This PR prevents sending blank messages to webinspectord after every sent message.

Fixes https://github.com/appium/appium/issues/13825