### PR TITLE
refactor: clean up callbacks and long parameter constructor

### DIFF
--- a/lib/afc/index.js
+++ b/lib/afc/index.js
@@ -20,7 +20,14 @@ class AfcService extends BaseServiceSocket {
   constructor (socketClient) {
     super(socketClient);
 
-    this._splitter = new LengthBasedSplitter(socketClient, true, MB, 8, 8, -8);
+    this._splitter = new LengthBasedSplitter({
+      readableStream: socketClient,
+      littleEndian: true,
+      maxFrameLength: MB,
+      lengthFieldOffset: 8,
+      lengthFieldLength: 8,
+      lengthAdjustment: -8,
+    });
     this._decoder = new AfcDecoder();
     this._socketClient.pipe(this._splitter).pipe(this._decoder);
 

--- a/lib/afc/index.js
+++ b/lib/afc/index.js
@@ -1,4 +1,4 @@
-/* eslint-disable promise/prefer-await-to-callbacks */
+
 import LengthBasedSplitter from '../util/transformer/length-based-splitter';
 import { Operations, operationCode, Errors, errorCode, FileModes } from './protocol';
 import { AfcWritableFileStream, AfcReadableFileStream } from './streams';
@@ -42,7 +42,7 @@ class AfcService extends BaseServiceSocket {
 
   _handleData (data) {
     const cb = this._responseCallbacks[data.packetNumber] || _.noop;
-    cb(data);
+    cb(data); // eslint-disable-line promise/prefer-await-to-callbacks
   }
 
   /**
@@ -252,7 +252,7 @@ class AfcService extends BaseServiceSocket {
    * @param {boolean} recursive Sets whether to follow sub directories or not
    * @param {WalkDirCallback} callback The callback to be called when a new path is found
    */
-  async walkDir (dir, recursive, callback) {
+  async walkDir (dir, recursive, onPath) {
     for (const file of await this.listDirectory(dir)) {
       if (IGNORED_PATHS.includes(file)) {
         continue;
@@ -260,9 +260,9 @@ class AfcService extends BaseServiceSocket {
       const relativePath = path.posix.join(dir, file);
       const fileInfo = await this.getFileInfo(relativePath);
       const isDirectory = fileInfo.isDirectory();
-      await callback(relativePath, isDirectory);
+      await onPath(relativePath, isDirectory);
       if (isDirectory && recursive) {
-        await this.walkDir(relativePath, recursive, callback);
+        await this.walkDir(relativePath, recursive, onPath);
       }
     }
   }

--- a/lib/afc/index.js
+++ b/lib/afc/index.js
@@ -12,6 +12,7 @@ import { BaseServiceSocket } from '../base-service';
 
 
 const AFC_SERVICE_NAME = 'com.apple.afc';
+const MAX_FRAME_SIZE = 1 * MB;
 
 const NULL_DELIMITER_CODE = 0x00;
 const IGNORED_PATHS = ['.', '..'];
@@ -23,7 +24,7 @@ class AfcService extends BaseServiceSocket {
     this._splitter = new LengthBasedSplitter({
       readableStream: socketClient,
       littleEndian: true,
-      maxFrameLength: MB,
+      maxFrameLength: MAX_FRAME_SIZE,
       lengthFieldOffset: 8,
       lengthFieldLength: 8,
       lengthAdjustment: -8,
@@ -250,7 +251,7 @@ class AfcService extends BaseServiceSocket {
    *
    * @param {string} dir The path in unix format
    * @param {boolean} recursive Sets whether to follow sub directories or not
-   * @param {WalkDirCallback} callback The callback to be called when a new path is found
+   * @param {WalkDirCallback} onPath The callback to be called when a new path is found
    */
   async walkDir (dir, recursive, onPath) {
     for (const file of await this.listDirectory(dir)) {

--- a/lib/afc/streams.js
+++ b/lib/afc/streams.js
@@ -1,6 +1,4 @@
-/* eslint-disable promise/catch-or-return */
 /* eslint-disable promise/prefer-await-to-then */
-/* eslint-disable promise/prefer-await-to-callbacks */
 import stream from 'stream';
 import _ from 'lodash';
 import log from '../logger';

--- a/lib/afc/transformer/afcdecoder.js
+++ b/lib/afc/transformer/afcdecoder.js
@@ -1,4 +1,3 @@
-/* eslint-disable promise/prefer-await-to-callbacks */
 import Stream from 'stream';
 import { MAGIC_NUMBER, AFC_PACKET_HEADER_SIZE } from '../protocol';
 
@@ -9,9 +8,9 @@ class AfcDecoder extends Stream.Transform {
     super({ objectMode: true });
   }
 
-  _transform (data, encoding, callback) {
+  _transform (data, encoding, onData) {
     this._decode(data);
-    callback();
+    onData();
   }
 
   _decode (data) {

--- a/lib/afc/transformer/afcencoder.js
+++ b/lib/afc/transformer/afcencoder.js
@@ -1,4 +1,3 @@
-/* eslint-disable promise/prefer-await-to-callbacks */
 import Stream from 'stream';
 import { MAGIC_NUMBER, AFC_PACKET_HEADER_SIZE } from '../protocol';
 
@@ -9,8 +8,8 @@ class AfcEncoder extends Stream.Transform {
     super({ objectMode: true });
   }
 
-  _transform (data, encoding, callback) {
-    callback(null, this._encode(data));
+  _transform (data, encoding, onData) {
+    onData(null, this._encode(data));
   }
 
   _encode (data) {

--- a/lib/house-arrest/index.js
+++ b/lib/house-arrest/index.js
@@ -8,6 +8,7 @@ import { BaseServiceSocket } from '../base-service';
 
 
 const HOUSE_ARREST_SERVICE_NAME = 'com.apple.mobile.house_arrest';
+const MAX_FRAME_SIZE = 1 * KB;
 
 class HouseArrestService extends BaseServiceSocket {
   constructor (socketClient) {
@@ -17,7 +18,7 @@ class HouseArrestService extends BaseServiceSocket {
     this._splitter = new LengthBasedSplitter({
       readableStream: socketClient,
       littleEndian: false,
-      maxFrameLength: KB,
+      maxFrameLength: MAX_FRAME_SIZE,
       lengthFieldOffset: 0,
       lengthFieldLength: 4,
       lengthAdjustment: 4,

--- a/lib/house-arrest/index.js
+++ b/lib/house-arrest/index.js
@@ -14,7 +14,14 @@ class HouseArrestService extends BaseServiceSocket {
     super(socketClient);
 
     this._decoder = new PlistServiceDecoder();
-    this._splitter = new LengthBasedSplitter(socketClient, false, KB, 0, 4, 4);
+    this._splitter = new LengthBasedSplitter({
+      readableStream: socketClient,
+      littleEndian: false,
+      maxFrameLength: KB,
+      lengthFieldOffset: 0,
+      lengthFieldLength: 4,
+      lengthAdjustment: 4,
+    });
     this._socketClient.pipe(this._splitter).pipe(this._decoder);
 
     this._encoder = new PlistServiceEncoder();

--- a/lib/notification-proxy/index.js
+++ b/lib/notification-proxy/index.js
@@ -15,7 +15,14 @@ class NotificationProxyService extends BaseServiceSocket {
     super(socketClient);
 
     this._decoder = new PlistServiceDecoder();
-    this._splitter = new LengthBasedSplitter(socketClient, false, 16 * KB, 0, 4, 4);
+    this._splitter = new LengthBasedSplitter({
+      readableStream: socketClient,
+      littleEndian: false,
+      maxFrameLength: 16 * KB,
+      lengthFieldOffset: 0,
+      lengthFieldLength: 4,
+      lengthAdjustment: 4,
+    });
     this._socketClient.pipe(this._splitter).pipe(this._decoder);
 
     this._encoder = new PlistServiceEncoder();

--- a/lib/notification-proxy/index.js
+++ b/lib/notification-proxy/index.js
@@ -7,6 +7,8 @@ import { BaseServiceSocket } from '../base-service';
 
 
 const NOTIFICATION_PROXY_SERVICE_NAME = 'com.apple.mobile.notification_proxy';
+const MAX_FRAME_SIZE = 16 * KB;
+
 const RELAY_NOTIFICATION = 'RelayNotification';
 const PROXY_DEATH = 'ProxyDeath';
 
@@ -18,7 +20,7 @@ class NotificationProxyService extends BaseServiceSocket {
     this._splitter = new LengthBasedSplitter({
       readableStream: socketClient,
       littleEndian: false,
-      maxFrameLength: 16 * KB,
+      maxFrameLength: MAX_FRAME_SIZE,
       lengthFieldOffset: 0,
       lengthFieldLength: 4,
       lengthAdjustment: 4,

--- a/lib/plist-service/index.js
+++ b/lib/plist-service/index.js
@@ -13,7 +13,14 @@ class PlistService extends BaseServiceSocket {
     super(socketClient);
 
     this._decoder = new PlistServiceDecoder();
-    this._splitter = new LengthBasedSplitter(socketClient, false, 1000000, 0, 4, 4);
+    this._splitter = new LengthBasedSplitter({
+      readableStream: socketClient,
+      littleEndian: false,
+      maxFrameLength: 1000000,
+      lengthFieldOffset: 0,
+      lengthFieldLength: 4,
+      lengthAdjustment: 4,
+    });
     this._socketClient.pipe(this._splitter).pipe(this._decoder);
 
     this._encoder = new PlistServiceEncoder();

--- a/lib/plist-service/index.js
+++ b/lib/plist-service/index.js
@@ -4,9 +4,10 @@ import PlistServiceEncoder from './transformer/plist-service-encoder';
 import PlistServiceDecoder from './transformer/plist-service-decoder';
 import LengthBasedSplitter from '../util/transformer/length-based-splitter';
 import { BaseServiceSocket } from '../base-service';
+import { MB } from '../constants';
 
 
-const MAX_FRAME_SIZE = 1000000;
+const MAX_FRAME_SIZE = 1 * MB;
 
 const CHECK_FREQ_MS = 50;
 

--- a/lib/plist-service/index.js
+++ b/lib/plist-service/index.js
@@ -6,6 +6,8 @@ import LengthBasedSplitter from '../util/transformer/length-based-splitter';
 import { BaseServiceSocket } from '../base-service';
 
 
+const MAX_FRAME_SIZE = 1000000;
+
 const CHECK_FREQ_MS = 50;
 
 class PlistService extends BaseServiceSocket {
@@ -16,7 +18,7 @@ class PlistService extends BaseServiceSocket {
     this._splitter = new LengthBasedSplitter({
       readableStream: socketClient,
       littleEndian: false,
-      maxFrameLength: 1000000,
+      maxFrameLength: MAX_FRAME_SIZE,
       lengthFieldOffset: 0,
       lengthFieldLength: 4,
       lengthAdjustment: 4,

--- a/lib/plist-service/transformer/plist-service-decoder.js
+++ b/lib/plist-service/transformer/plist-service-decoder.js
@@ -1,4 +1,3 @@
-/* eslint-disable promise/prefer-await-to-callbacks */
 import _ from 'lodash';
 import Stream from 'stream';
 import { plist } from 'appium-support';
@@ -11,9 +10,9 @@ class PlistServiceDecoder extends Stream.Transform {
     super({ objectMode: true });
   }
 
-  _transform (data, encoding, callback) {
+  _transform (data, encoding, onData) {
     this._decode(data);
-    callback();
+    onData();
   }
 
   _decode (data) {

--- a/lib/plist-service/transformer/plist-service-encoder.js
+++ b/lib/plist-service/transformer/plist-service-encoder.js
@@ -1,4 +1,3 @@
-/* eslint-disable promise/prefer-await-to-callbacks */
 import Stream from 'stream';
 import { plist } from 'appium-support';
 
@@ -10,9 +9,9 @@ class PlistServiceEncoder extends Stream.Transform {
     super({ objectMode: true });
   }
 
-  _transform (data, encoding, callback) {
+  _transform (data, encoding, onData) {
     this.push(this._encode(data), 'buffer');
-    callback();
+    onData();
   }
 
   _encode (data) {

--- a/lib/services.js
+++ b/lib/services.js
@@ -9,12 +9,15 @@ import { HouseArrestService, HOUSE_ARREST_SERVICE_NAME } from './house-arrest';
 import PlistService from './plist-service';
 import semver from 'semver';
 
+
 async function startSyslogService (udid, opts = {}) {
-  return await startService(udid, SYSLOG_SERVICE_NAME, opts.socket, (socket) => new SyslogService(socket));
+  const socket = await startService(udid, SYSLOG_SERVICE_NAME, opts.socket);
+  return new SyslogService(socket);
 }
 
 async function startSimulateLocationService (udid, opts = {}) {
-  return await startService(udid, SIMULATE_LOCATION_SERVICE_NAME, opts.socket, (socket) => new SimulateLocationService(socket));
+  const socket = await startService(udid, SIMULATE_LOCATION_SERVICE_NAME, opts.socket);
+  return new SimulateLocationService(socket);
 }
 
 async function startWebInspectorService (udid, opts = {}) {
@@ -37,40 +40,45 @@ async function startWebInspectorService (udid, opts = {}) {
       socketClient: opts.socket,
     });
   }
-  return await startService(udid, WEB_INSPECTOR_SERVICE_NAME, undefined, (socketClient) => new WebInspectorService({
+  const socket = await startService(udid, WEB_INSPECTOR_SERVICE_NAME, undefined);
+  return new WebInspectorService({
     majorOsVersion: semverVersion.major,
     isSimulator,
     socketChunkSize,
     verbose,
     verboseHexDump,
-    socketClient,
-  }));
+    socketClient: socket,
+  });
 }
 
 async function startInstallationProxyService (udid, opts = {}) {
-  return await startService(udid, INSTALLATION_PROXY_SERVICE_NAME, opts.socket, (socket) => new InstallationProxyService(new PlistService(socket)));
+  const socket = await startService(udid, INSTALLATION_PROXY_SERVICE_NAME, opts.socket);
+  return new InstallationProxyService(new PlistService(socket));
 }
 
 async function startAfcService (udid, opts = {}) {
-  return await startService(udid, AFC_SERVICE_NAME, opts.socket, (socket) => new AfcService(socket));
+  const socket = await startService(udid, AFC_SERVICE_NAME, opts.socket);
+  return new AfcService(socket);
 }
 
 async function startNotificationProxyService (udid, opts = {}) {
-  return await startService(udid, NOTIFICATION_PROXY_SERVICE_NAME, opts.socket, (socket) => new NotificationProxyService(socket));
+  const socket = await startService(udid, NOTIFICATION_PROXY_SERVICE_NAME, opts.socket);
+  return new NotificationProxyService(socket);
 }
 
 async function startHouseArrestService (udid, opts = {}) {
-  return await startService(udid, HOUSE_ARREST_SERVICE_NAME, opts.socket, (socket) => new HouseArrestService(socket));
+  const socket = await startService(udid, HOUSE_ARREST_SERVICE_NAME, opts.socket);
+  return new HouseArrestService(socket);
 }
 
-async function startService (udid, serviceName, socket, onConnect) {
+async function startService (udid, serviceName, socket) {
   const lockdown = await startLockdownSession(udid, socket);
   try {
     const service = await lockdown.startService(serviceName);
     if (service.EnableServiceSSL) {
-      return await connectPortSSL(udid, service.Port, socket, onConnect);
+      return await connectPortSSL(udid, service.Port, socket);
     } else {
-      return await connectPort(udid, service.Port, socket, onConnect);
+      return await connectPort(udid, service.Port, socket);
     }
   } finally {
     lockdown.close();

--- a/lib/syslog/index.js
+++ b/lib/syslog/index.js
@@ -23,7 +23,7 @@ class SyslogService extends BaseServiceSocket {
 
   /**
    * Start recieving logs from the phone. The callback when a log is recieved
-   * @param {LogCallback} callback
+   * @param {LogCallback} onData
    */
   start (onData) {
     this._decoder.on('data', onData);

--- a/lib/syslog/index.js
+++ b/lib/syslog/index.js
@@ -1,4 +1,3 @@
-/* eslint-disable promise/prefer-await-to-callbacks */
 import SyslogDecoder from './transformer/syslog-decoder';
 import { KB } from '../constants';
 import { BaseServiceSocket } from '../base-service';
@@ -26,8 +25,8 @@ class SyslogService extends BaseServiceSocket {
    * Start recieving logs from the phone. The callback when a log is recieved
    * @param {LogCallback} callback
    */
-  start (callback) {
-    this._decoder.on('data', callback);
+  start (onData) {
+    this._decoder.on('data', onData);
     this._socketClient.write(START_MESSAGE);
   }
 }

--- a/lib/syslog/transformer/syslog-decoder.js
+++ b/lib/syslog/transformer/syslog-decoder.js
@@ -1,4 +1,3 @@
-/* eslint-disable promise/prefer-await-to-callbacks */
 import Stream from 'stream';
 
 const NEW_LINE_CODE = 0x0A;
@@ -12,9 +11,9 @@ class SyslogDecoder extends Stream.Transform {
     this.buffer = Buffer.allocUnsafe(bufferLength);
   }
 
-  _transform (data, encoding, callback) {
+  _transform (data, encoding, onData) {
     this._decode(data);
-    callback();
+    onData();
   }
 
   _decode (data) {

--- a/lib/usbmux/index.js
+++ b/lib/usbmux/index.js
@@ -11,6 +11,8 @@ import { Lockdown, LOCKDOWN_PORT } from '../lockdown';
 import { BaseServiceSocket } from '../base-service';
 
 
+const MAX_FRAME_SIZE = 1000000;
+
 const USBMUX_RESULT = {
   OK: 0,
   BADCOMMAND: 1,
@@ -43,7 +45,7 @@ class Usbmux extends BaseServiceSocket {
     this._splitter = new LengthBasedSplitter({
       readableStream: socketClient,
       littleEndian: true,
-      maxFrameLength: 1000000,
+      maxFrameLength: MAX_FRAME_SIZE,
       lengthFieldOffset: 0,
       lengthFieldLength: 4,
       lengthAdjustment: 0,

--- a/lib/usbmux/index.js
+++ b/lib/usbmux/index.js
@@ -41,7 +41,14 @@ class Usbmux extends BaseServiceSocket {
     super(socketClient);
 
     this._decoder = new UsbmuxDecoder();
-    this._splitter = new LengthBasedSplitter(socketClient, true, 1000000, 0, 4, 0);
+    this._splitter = new LengthBasedSplitter({
+      readableStream: socketClient,
+      littleEndian: true,
+      maxFrameLength: 1000000,
+      lengthFieldOffset: 0,
+      lengthFieldLength: 4,
+      lengthAdjustment: 0,
+    });
     this._socketClient.pipe(this._splitter).pipe(this._decoder);
 
     this._encoder = new UsbmuxEncoder();

--- a/lib/usbmux/index.js
+++ b/lib/usbmux/index.js
@@ -1,4 +1,3 @@
-/* eslint-disable promise/prefer-await-to-callbacks */
 import net from 'net';
 import _ from 'lodash';
 import B from 'bluebird';
@@ -185,25 +184,18 @@ class Usbmux extends BaseServiceSocket {
     if (!device) {
       throw new Error(`Could not find the expected device '${udid}'`);
     }
-    return await this.connect(device.Properties.DeviceID, LOCKDOWN_PORT, timeout, (socket) => new Lockdown(new PlistService(socket)));
+    const socket = await this.connect(device.Properties.DeviceID, LOCKDOWN_PORT, timeout);
+    return new Lockdown(new PlistService(socket));
   }
-
-  /** The callback function which will be when connect succeeds synchronously
-   * @name ConnectCallback
-   * @function
-   * @param {net.Socket} socket the socket for the communication to the phone
-   * @returns {Object} The object returned in the callback function
-  */
 
   /**
    * Connects to a certain port on the device
    * @param {string} deviceID the device id which can be retrieved from the properties of a device
    * @param {number} port the port number that wants to be connected
    * @param {number} [timeout=5000] the timeout of receiving a response from usbmuxd
-   * @param {?ConnectCallback} callback The callback function which will be when connect succeeds synchronously
    * @returns {net.Socket|Object} The socket or the object returned in the callback if the callback function exists
    */
-  async connect (deviceID, port, timeout = 5000, callback) {
+  async connect (deviceID, port, timeout = 5000) {
     const {tag, receivePromise} = this._receivePlistPromise(timeout, (data) => {
       if (data.payload.MessageType !== 'Result') {
         throw new Error(`Unexpected data: ${JSON.stringify(data)}`);
@@ -212,7 +204,7 @@ class Usbmux extends BaseServiceSocket {
         this._splitter.shutdown();
         this._socketClient.unpipe(this._splitter);
         this._splitter.unpipe(this._decoder);
-        return _.isFunction(callback) ? callback(this._socketClient) : this._socketClient;
+        return this._socketClient;
       } else if (data.payload.Number === USBMUX_RESULT.CONNREFUSED) {
         throw new Error(`Connection was refused to port ${port}`);
       } else {

--- a/lib/usbmux/index.js
+++ b/lib/usbmux/index.js
@@ -9,9 +9,10 @@ import path from 'path';
 import PlistService from '../plist-service';
 import { Lockdown, LOCKDOWN_PORT } from '../lockdown';
 import { BaseServiceSocket } from '../base-service';
+import { MB } from '../constants';
 
 
-const MAX_FRAME_SIZE = 1000000;
+const MAX_FRAME_SIZE = 1 * MB;
 
 const USBMUX_RESULT = {
   OK: 0,

--- a/lib/usbmux/transformer/usbmux-decoder.js
+++ b/lib/usbmux/transformer/usbmux-decoder.js
@@ -1,4 +1,3 @@
-/* eslint-disable promise/prefer-await-to-callbacks */
 import Stream from 'stream';
 import { plist } from 'appium-support';
 
@@ -10,9 +9,9 @@ class UsbmuxDecoder extends Stream.Transform {
     super({ objectMode: true });
   }
 
-  _transform (data, encoding, callback) {
+  _transform (data, encoding, onData) {
     this._decode(data);
-    callback();
+    onData();
   }
 
   _decode (data) {

--- a/lib/usbmux/transformer/usbmux-encoder.js
+++ b/lib/usbmux/transformer/usbmux-encoder.js
@@ -1,4 +1,3 @@
-/* eslint-disable promise/prefer-await-to-callbacks */
 import Stream from 'stream';
 import { plist } from 'appium-support';
 
@@ -11,9 +10,9 @@ class UsbmuxEncoder extends Stream.Transform {
     super({ objectMode: true });
   }
 
-  _transform (data, encoding, callback) {
+  _transform (data, encoding, onData) {
     this._encode(data);
-    callback();
+    onData();
   }
 
   _encode (data) {

--- a/lib/util/transformer/length-based-splitter.js
+++ b/lib/util/transformer/length-based-splitter.js
@@ -3,9 +3,18 @@ import Stream from 'stream';
 import log from '../../logger';
 
 class LengthBasedSplitter extends Stream.Transform {
-
-  constructor (readableStream, littleEndian, maxFrameLength, lengthFieldOffset, lengthFieldLength, lengthAdjustment) {
+  constructor (opts) {
     super();
+
+    const {
+      readableStream,
+      littleEndian,
+      maxFrameLength,
+      lengthFieldOffset,
+      lengthFieldLength,
+      lengthAdjustment,
+    } = opts;
+
     this.readableStream = readableStream;
     this.littleEndian = littleEndian;
     this.maxFrameLength = maxFrameLength;

--- a/lib/util/transformer/length-based-splitter.js
+++ b/lib/util/transformer/length-based-splitter.js
@@ -1,4 +1,3 @@
-/* eslint-disable promise/prefer-await-to-callbacks */
 import Stream from 'stream';
 import log from '../../logger';
 
@@ -27,13 +26,13 @@ class LengthBasedSplitter extends Stream.Transform {
     this._frameBuffer = Buffer.allocUnsafeSlow(maxFrameLength);
   }
 
-  _transform (data, encoding, callback) {
+  _transform (data, encoding, onData) {
     for (let i = 0; i < data.length; i = this._decode(data, i)) {
       if (this.isShutdown) {
         return this._pushBack(i, data.length, data);
       }
     }
-    callback();
+    onData();
   }
 
   _decode (data, pos) {

--- a/lib/util/transformer/stream-logger.js
+++ b/lib/util/transformer/stream-logger.js
@@ -1,4 +1,3 @@
-/* eslint-disable promise/prefer-await-to-callbacks */
 import Stream from 'stream';
 import _ from 'lodash';
 import log from '../../logger';
@@ -17,7 +16,7 @@ class StreamLogger extends Stream.Transform {
     this._verbose = verbose;
   }
 
-  _transform (data, encoding, callback) {
+  _transform (data, encoding, onData) {
     if (this._verbose) {
       try {
         this._log(data);
@@ -29,7 +28,7 @@ class StreamLogger extends Stream.Transform {
     }
 
     this.push(data);
-    callback();
+    onData();
   }
 
   _log (data) {

--- a/lib/utilities.js
+++ b/lib/utilities.js
@@ -138,8 +138,7 @@ async function connectPortSSL (udid, port, socket) {
       throw new Error(`Could not find a pair record for device '${udid}'. Please first pair with the device`);
     }
     const socket = await usbmux.connect(device.Properties.DeviceID, port, undefined);
-    const sslSocket = upgradeToSSL(socket, pairRecord.HostPrivateKey, pairRecord.HostCertificate);
-    return sslSocket;
+    return upgradeToSSL(socket, pairRecord.HostPrivateKey, pairRecord.HostCertificate);
   } catch (e) {
     usbmux.close();
     throw e;

--- a/lib/utilities.js
+++ b/lib/utilities.js
@@ -124,10 +124,9 @@ async function startLockdownSession (udid, socket) {
  * @param {string} udid Device UDID
  * @param {number} port Port to connect
  * @param {?net.Socket} socket the socket of usbmuxd. It will default to /var/run/usbmuxd if it is not passed
- * @param {?usbmux.ConnectCallback} callback The callback function which will be when connect succeeds synchronously
  * @returns {tls.TLSSocket|Object} The socket or the object returned in the callback if the callback function exists
  */
-async function connectPortSSL (udid, port, socket, callback) {
+async function connectPortSSL (udid, port, socket) {
   const usbmux = new Usbmux(socket);
   try {
     const device = await usbmux.findDevice(udid);
@@ -138,10 +137,9 @@ async function connectPortSSL (udid, port, socket, callback) {
     if (!pairRecord) {
       throw new Error(`Could not find a pair record for device '${udid}'. Please first pair with the device`);
     }
-    return await usbmux.connect(device.Properties.DeviceID, port, undefined, (socket) => {
-      const sslSocket = upgradeToSSL(socket, pairRecord.HostPrivateKey, pairRecord.HostCertificate);
-      return _.isFunction(callback) ? callback(sslSocket) : sslSocket;
-    });
+    const socket = await usbmux.connect(device.Properties.DeviceID, port, undefined);
+    const sslSocket = upgradeToSSL(socket, pairRecord.HostPrivateKey, pairRecord.HostCertificate);
+    return sslSocket;
   } catch (e) {
     usbmux.close();
     throw e;
@@ -154,17 +152,16 @@ async function connectPortSSL (udid, port, socket, callback) {
  * @param {string} udid Device UDID
  * @param {number} port Port to connect
  * @param {?net.Socket} socket the socket of usbmuxd. It will default to /var/run/usbmuxd if it is not passed
- * @param {?usbmux.ConnectCallback} callback The callback function which will be when connect succeeds synchronously
  * @returns {net.Socket|Object} The socket or the object returned in the callback if the callback function exists
  */
-async function connectPort (udid, port, socket, callback) {
+async function connectPort (udid, port, socket) {
   const usbmux = new Usbmux(socket);
   try {
     const device = await usbmux.findDevice(udid);
     if (!device) {
       throw new Error(`Could not find the expected device ${udid}`);
     }
-    return await usbmux.connect(device.Properties.DeviceID, port, undefined, callback);
+    return await usbmux.connect(device.Properties.DeviceID, port, undefined);
   } catch (e) {
     usbmux.close();
     throw e;

--- a/lib/webinspector/index.js
+++ b/lib/webinspector/index.js
@@ -82,7 +82,14 @@ class WebInspectorService extends BaseServiceSocket {
     this._socketClient
       // log first, in case there is a problem in processing
       .pipe(new StreamLogger(StreamLogger.RECEIVE, verbose))
-      .pipe(new LengthBasedSplitter(this._socketClient, false, MAX_FRAME_SIZE, 0, 4, 4))
+      .pipe(this._splitter = new LengthBasedSplitter({
+        readableStream: this._socketClient,
+        littleEndian: false,
+        maxFrameLength: MAX_FRAME_SIZE,
+        lengthFieldOffset: 0,
+        lengthFieldLength: 4,
+        lengthAdjustment: 4,
+      }))
       .pipe(this._decoder);
 
     this._encoder = new PlistServiceEncoder();
@@ -103,7 +110,14 @@ class WebInspectorService extends BaseServiceSocket {
     this._socketClient
       // log first, in case there is a problem in processing
       .pipe(new StreamLogger(StreamLogger.RECEIVE, verbose))
-      .pipe(new LengthBasedSplitter(this._socketClient, false, MAX_FRAME_SIZE, 0, 4, 4))
+      .pipe(this._splitter = new LengthBasedSplitter({
+        readableStream: this._socketClient,
+        littleEndian: false,
+        maxFrameLength: MAX_FRAME_SIZE,
+        lengthFieldOffset: 0,
+        lengthFieldLength: 4,
+        lengthAdjustment: 4,
+      }))
       .pipe(new PlistServiceDecoder())
       .pipe(this._decoder);
 

--- a/lib/webinspector/index.js
+++ b/lib/webinspector/index.js
@@ -12,10 +12,9 @@ import { BaseServiceSocket } from '../base-service';
 
 
 const WEB_INSPECTOR_SERVICE_NAME = 'com.apple.webinspector';
+const MAX_FRAME_SIZE = 20 * MB;
 
 const PARTIAL_MESSAGE_SUPPORT_DEPRECATION_VERSION = 11;
-
-const MAX_FRAME_SIZE = 20 * MB;
 
 /**
  * @typedef {Object} WebInspectorServiceOptions

--- a/lib/webinspector/index.js
+++ b/lib/webinspector/index.js
@@ -1,4 +1,3 @@
-/* eslint-disable promise/prefer-await-to-callbacks */
 import WebInspectorDecoder from './transformer/webinspector-decoder';
 import WebInspectorEncoder from './transformer/webinspector-encoder';
 import PlistServiceDecoder from '../plist-service/transformer/plist-service-decoder';

--- a/lib/webinspector/transformer/webinspector-decoder.js
+++ b/lib/webinspector/transformer/webinspector-decoder.js
@@ -1,4 +1,3 @@
-/* eslint-disable promise/prefer-await-to-callbacks */
 import Stream from 'stream';
 import { plist } from 'appium-support';
 
@@ -10,9 +9,9 @@ class WebInspectorDecoder extends Stream.Transform {
     this._frameBuffer = Buffer.allocUnsafeSlow(maxLength);
   }
 
-  _transform (data, encoding, callback) {
+  _transform (data, encoding, onData) {
     this._decode(data);
-    callback();
+    onData();
   }
 
   _decode (data) {

--- a/lib/webinspector/transformer/webinspector-encoder.js
+++ b/lib/webinspector/transformer/webinspector-encoder.js
@@ -1,4 +1,3 @@
-/* eslint-disable promise/prefer-await-to-callbacks */
 import Stream from 'stream';
 import { plist } from 'appium-support';
 
@@ -10,10 +9,10 @@ class WebInspectorEncoder extends Stream.Transform {
     super({ objectMode: true });
   }
 
-  _transform (data, encoding, callback) {
+  _transform (data, encoding, onData) {
     let payloadBuffer = plist.createPlist(data, true);
     for (let i = 0; i < payloadBuffer.length; i += this._encode(payloadBuffer, i)) {}
-    callback();
+    onData();
   }
 
   _encode (data, pos) {

--- a/test/usbmux/usbmux-specs.js
+++ b/test/usbmux/usbmux-specs.js
@@ -62,11 +62,11 @@ describe('usbmux', function () {
     await usbmux.connectLockdown(UDID);
   });
 
-  it('should swicht decoders correctly', async function () {
+  it('should switch decoders correctly', async function () {
     ({server, socket} = await getServerWithFixtures(fixtures.DEVICE_LIST, fixtures.USBMUX_TO_LOCKDOWN));
     usbmux = new Usbmux(socket);
 
     const lockdown = await usbmux.connectLockdown(UDID);
-    await lockdown.getValue({ Key: 'TimeIntervalSince1970' });
+    await lockdown.getValue({Key: 'TimeIntervalSince1970'});
   });
 });


### PR DESCRIPTION
This PR refactors two elements:
1. Moves `LengthBasedSplitter` to use options rather than a long list of parameters
1. Cleans up callbacks
    1. Gets rid of most global eslint disabling, which can obscure bad patterns, and in most cases were unnecessary (e.g., callbacks not named `cb` or `callback` do not trigger the warning).
    1. Gets rid of the connection callbacks, which were only used internally and just made the flow of information obscure. In all cases these could be handled by getting the socket and then doing whatever transformation was needed in the calling function.