### PR TITLE
feat: Add time zone name to the getDeviceTime result

### DIFF
--- a/lib/utilities.js
+++ b/lib/utilities.js
@@ -3,9 +3,11 @@ import { upgradeToSSL } from './ssl-helper';
 import _ from 'lodash';
 import log from './logger';
 
+// https://github.com/samdmarshall/iOS-Internals/blob/master/lockbot/lockbot/lockdown_keys.h
 const LOCKDOWN_REQUEST = {
   DEVICE_TIME: { Key: 'TimeIntervalSince1970' },
   DEVICE_UTC_OFFSET: { Key: 'TimeZoneOffsetFromUTC' },
+  DEVICE_TIME_ZONE: { Key: 'TimeZone' },
   DEVICE_VERSION: { Key: 'ProductVersion' },
   DEVICE_NAME: { Key: 'DeviceName' }
 };
@@ -75,8 +77,9 @@ async function getDeviceName (udid, socket = null) {
  * @typedef {Object} DeviceTime
  *
  * @property {number} timestamp Unix timestamp in seconds since 1970-01-01T00:00:00Z
- * @property {number} utcOffset The difference in seconds between the UTC time and the local device time.
+ * @property {number} utcOffset The difference in minutes between the UTC time and the local device time.
  * Can be negative.
+ * @property {string} timeZone Time zone name configured on the device, for example `Europe/Paris`
  */
 
 /**
@@ -89,12 +92,11 @@ async function getDeviceName (udid, socket = null) {
 async function getDeviceTime (udid, socket = null) {
   const lockdown = await startLockdownSession(udid, socket);
   try {
-    const timestamp = await lockdown.getValue(LOCKDOWN_REQUEST.DEVICE_TIME);
-    // Apple returns utcOffset in seconds which doesnt comply with the general standard
-    const utcOffset = await lockdown.getValue(LOCKDOWN_REQUEST.DEVICE_UTC_OFFSET) / 60;
     return {
-      timestamp,
-      utcOffset,
+      timestamp: await lockdown.getValue(LOCKDOWN_REQUEST.DEVICE_TIME),
+      // Apple returns utcOffset in seconds which doesnt comply with the general standard
+      utcOffset: await lockdown.getValue(LOCKDOWN_REQUEST.DEVICE_UTC_OFFSET) / 60,
+      timeZone: await lockdown.getValue(LOCKDOWN_REQUEST.DEVICE_TIME_ZONE),
     };
   } finally {
     lockdown.close();


### PR DESCRIPTION
It looks Apple did change something recently in the lockdown protocol, so `TimeZoneOffsetFromUTC` does not return a [proper offset](https://discuss.appium.io/t/appium-1-17-getdevicetime-returns-strange-value/30162) anymore. I'll try to set the UTC offset based on the time zone name instead