### PR TITLE
feat: make maxFrameLength configurable

### DIFF
--- a/lib/services.js
+++ b/lib/services.js
@@ -27,6 +27,7 @@ async function startWebInspectorService (udid, opts = {}) {
   const verboseHexDump = !!opts.verboseHexDump;
   const socketChunkSize = opts.socketChunkSize;
   const semverVersion = semver.coerce(osVersion);
+  const maxFrameLength = opts.maxFrameLength;
   if (!semverVersion) {
     throw new Error(`Could not create a semver version out of '${osVersion}'`);
   }
@@ -38,6 +39,7 @@ async function startWebInspectorService (udid, opts = {}) {
       verbose,
       verboseHexDump,
       socketClient: opts.socket,
+      maxFrameLength,
     });
   }
   const socket = await startService(udid, WEB_INSPECTOR_SERVICE_NAME, undefined);
@@ -48,6 +50,7 @@ async function startWebInspectorService (udid, opts = {}) {
     verbose,
     verboseHexDump,
     socketClient: socket,
+    maxFrameLength,
   });
 }
 

--- a/lib/webinspector/index.js
+++ b/lib/webinspector/index.js
@@ -28,6 +28,10 @@ const PARTIAL_MESSAGE_SUPPORT_DEPRECATION_VERSION = 11;
  *                             Defaults to false
  * @property {boolean} verboseHexDump Turn on logging of _all_ communication as
  *                                    hex dump. Defaults to false
+ * @property {number} [maxFrameLength=MAX_FRAME_SIZE] The maximum frame size
+ *                                    to get data by Safari Web inspector.
+ *                                    Increasing ths value may help to get
+ *                                    large amount of data/Web Page by the web inspector,
  * @property {*} socketClient The socket client where the communication will happen
  */
 
@@ -45,6 +49,7 @@ class WebInspectorService extends BaseServiceSocket {
       verbose = false,
       verboseHexDump = false,
       socketClient,
+      maxFrameLength = MAX_FRAME_SIZE,
     } = opts;
 
     super(socketClient);
@@ -64,9 +69,9 @@ class WebInspectorService extends BaseServiceSocket {
     this._majorOsVersion = majorOsVersion;
 
     if (!isSimulator && majorOsVersion < PARTIAL_MESSAGE_SUPPORT_DEPRECATION_VERSION) {
-      this._initializePartialMessageSupport(verboseHexDump);
+      this._initializePartialMessageSupport(verboseHexDump, maxFrameLength);
     } else {
-      this._initializeFullMessageSupport(verboseHexDump);
+      this._initializeFullMessageSupport(verboseHexDump, maxFrameLength);
     }
   }
 
@@ -74,8 +79,9 @@ class WebInspectorService extends BaseServiceSocket {
    * Intializes the data flow for iOS 11+.
    *
    * @param {boolean} verbose - whether to print out the hex dump for communication
+   * @param {number} [maxFrameLength=MAX_FRAME_SIZE] - The maximum frame size to get by web inspector
    */
-  _initializeFullMessageSupport (verbose) {
+  _initializeFullMessageSupport (verbose, maxFrameLength = MAX_FRAME_SIZE) {
     this._decoder = new PlistServiceDecoder();
     this._socketClient
       // log first, in case there is a problem in processing
@@ -83,7 +89,7 @@ class WebInspectorService extends BaseServiceSocket {
       .pipe(this._splitter = new LengthBasedSplitter({
         readableStream: this._socketClient,
         littleEndian: false,
-        maxFrameLength: MAX_FRAME_SIZE,
+        maxFrameLength,
         lengthFieldOffset: 0,
         lengthFieldLength: 4,
         lengthAdjustment: 4,
@@ -101,8 +107,9 @@ class WebInspectorService extends BaseServiceSocket {
    * messages before sending.
    *
    * @param {boolean} verbose - whether to print out the hex dump for communication
+   * @param {number} [maxFrameLength=MAX_FRAME_SIZE] - The maximum frame size to get by web inspector
    */
-  _initializePartialMessageSupport (verbose) {
+  _initializePartialMessageSupport (verbose, maxFrameLength = MAX_FRAME_SIZE) {
     // 1MB as buffer for bulding webinspector full messages. We can increase the value if more buffer is needed
     this._decoder = new WebInspectorDecoder(MB);
     this._socketClient
@@ -111,7 +118,7 @@ class WebInspectorService extends BaseServiceSocket {
       .pipe(this._splitter = new LengthBasedSplitter({
         readableStream: this._socketClient,
         littleEndian: false,
-        maxFrameLength: MAX_FRAME_SIZE,
+        maxFrameLength,
         lengthFieldOffset: 0,
         lengthFieldLength: 4,
         lengthAdjustment: 4,

--- a/lib/webinspector/index.js
+++ b/lib/webinspector/index.js
@@ -68,6 +68,8 @@ class WebInspectorService extends BaseServiceSocket {
     this._isSimulator = isSimulator;
     this._majorOsVersion = majorOsVersion;
 
+    log.debug(`Max frame length for Web Inspector is ${maxFrameLength}`);
+
     if (!isSimulator && majorOsVersion < PARTIAL_MESSAGE_SUPPORT_DEPRECATION_VERSION) {
       this._initializePartialMessageSupport(verboseHexDump, maxFrameLength);
     } else {


### PR DESCRIPTION
According to https://github.com/appium/appium/issues/14332#issuecomment-647232293 , relaxing the max size may help to find large size Web Context.

Like `logAllCommunicationHexDump`, I'm thinking to make the value also configurable.
https://github.com/appium/appium-remote-debugger/search?q=startWebInspectorService&unscoped_q=startWebInspectorService