### PR TITLE
[feat] Connect to usbmuxd on 127.0.0.1:27015 when running on WSL1

### DIFF
--- a/lib/usbmux/index.js
+++ b/lib/usbmux/index.js
@@ -1,4 +1,5 @@
 import net from 'net';
+import os from 'os';
 import _ from 'lodash';
 import B from 'bluebird';
 import { plist, fs } from 'appium-support';
@@ -31,6 +32,8 @@ try {
 }
 
 const DEFAULT_USBMUXD_SOCKET = '/var/run/usbmuxd';
+const DEFAULT_USBMUXD_PORT = 27015;
+const DEFAULT_USBMUXD_HOST = '127.0.0.1';
 const PROG_NAME = name;
 const CLIENT_VERSION_STRING = `${name}-${version}`;
 
@@ -49,13 +52,26 @@ function swap16 (val) {
  * @throws {B.TimeoutError} if connection timeout happened
  * @returns {net.Socket} Connected socket instance
  */
-async function getDefaultSocket (socketPath = DEFAULT_USBMUXD_SOCKET, timeout = 5000) {
-  if (!await fs.exists(socketPath)) {
+async function getDefaultSocket (opts = {}) {
+  const {
+    socketPath = DEFAULT_USBMUXD_SOCKET,
+    socketPort = DEFAULT_USBMUXD_PORT,
+    socketHost = DEFAULT_USBMUXD_HOST,
+    timeout = 5000,
+  } = opts;
+
+  let socket;
+  if (await fs.exists(socketPath)) {
+    socket = net.createConnection(socketPath);
+  } else if (process.platform === 'win32'
+      || (process.platform === 'linux' && /microsoft/i.test(os.release()))) {
+    // Connect to usbmuxd when running on WSL1
+    socket = net.createConnection(socketPort, socketHost);
+  } else {
     throw new Error(`The usbmuxd socket at '${socketPath}' does not exist or is not accessible`);
   }
 
   return await new B((resolve, reject) => {
-    const socket = net.createConnection(socketPath);
     socket.once('error', reject);
     socket.once('connect', () => resolve(socket));
   }).timeout(timeout);


### PR DESCRIPTION
On Windows, the equivalent of usbmuxd is the Apple Mobile Device Manager which runs on `127.0.0.1:27015`.

This PR modifies the `getDefaultSocket` routine to connect to `127.0.0.1:27015` when appium-ios-device (and hence, Appium) is running on WSL.

With this change, most of the appium-ios-device code runs correctly on WSL.