### PR TITLE
fix: exception on getDeviceTime for eu west based devices

### DIFF
--- a/lib/lockdown/index.js
+++ b/lib/lockdown/index.js
@@ -77,7 +77,7 @@ class Lockdown extends BaseServicePlist {
     };
     Object.assign(plist, query);
     const data = await this._plistService.sendPlistAndReceive(plist, timeout);
-    if (data.Request === 'GetValue' && data.Value) {
+    if (data.Request === 'GetValue' && (data.Value == 0 || data.Value)) {
       return data.Value;
     } else {
       throw new Error(`Unexpected data: ${JSON.stringify(data)}`);


### PR DESCRIPTION
skips getDevicetime exception for value 0 thus avoiding exception for genuine cases
fixes  #77 