### PR TITLE
feat: get usbmuxd socket address from USBMUXD_SOCKET_ADDRESS environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,9 @@ More information can be found at the links below:
 - `services.startNotificationProxyService`
 - `services.startHouseArrestService`
 
+### Environment
+- `USBMUXD_SOCKET_ADDRESS` follow [libusbmuxd](https://github.com/libimobiledevice/libusbmuxd) to get usbmuxd socket address from USBMUXD_SOCKET_ADDRESS environment.
+
 ### Usage
 
 This module should be used over the `utilities` and `services` modules due to the complexity of iOS communication. When a new services is implemented, it should be added and made available over the `services` module

--- a/lib/usbmux/index.js
+++ b/lib/usbmux/index.js
@@ -1,5 +1,6 @@
 import net from 'net';
 import os from 'os';
+import url from 'url';
 import _ from 'lodash';
 import B from 'bluebird';
 import { plist, fs } from 'appium-support';
@@ -62,12 +63,24 @@ function swap16 (val) {
  * @returns {net.Socket} Connected socket instance
  */
 async function getDefaultSocket (opts = {}) {
-  const {
+  let {
     socketPath = DEFAULT_USBMUXD_SOCKET,
     socketPort = DEFAULT_USBMUXD_PORT,
     socketHost = DEFAULT_USBMUXD_HOST,
     timeout = 5000,
   } = opts;
+
+  let usbmuxdSocketAddress = process.env.USBMUXD_SOCKET_ADDRESS;
+  if (usbmuxdSocketAddress) {
+    let parsedAddr = url.parse(usbmuxdSocketAddress);
+    if (parsedAddr.protocol === 'unix:') {
+      socketPath = parsedAddr.pathname;
+    } else {
+      let ipPortPair = usbmuxdSocketAddress.split(':');
+      socketHost = ipPortPair[0];
+      socketPort = ipPortPair[1];
+    }
+  }
 
   let socket;
   if (await fs.exists(socketPath)) {


### PR DESCRIPTION
follow [libusbmuxd](https://github.com/libimobiledevice/libusbmuxd), get usbmuxd socket address from USBMUXD_SOCKET_ADDRESS environment