### PR TITLE
feat: Add a possibility to upgrade an application

### DIFF
--- a/lib/installation-proxy/index.js
+++ b/lib/installation-proxy/index.js
@@ -1,6 +1,10 @@
 import _ from 'lodash';
 import { BaseServicePlist } from '../base-service';
 
+/*
+ * https://github.com/tmothy20013/libimobiledevice-master/blob/ecd89b42021cf6f7efe9ad271b3bddc7dd4b281e/src/installation_proxy.c
+ */
+
 const INSTALLATION_PROXY_SERVICE_NAME = 'com.apple.mobile.installation_proxy';
 
 class InstallationProxyService extends BaseServicePlist {
@@ -13,6 +17,26 @@ class InstallationProxyService extends BaseServicePlist {
   async installApplication (path, clientOptions = {}, timeout = 60000) {
     const request = {
       Command: 'Install',
+      PackagePath: path,
+      ClientOptions: clientOptions
+    };
+
+    this._plistService.sendPlist(request);
+    return await this._waitMessageCompletion(timeout);
+  }
+
+  /**
+   * Upgrades the given application from the relative path on the phone.
+   * It is required that a previous version of the same app is already installed in order
+   * to call this API.
+   *
+   * @param {string} path The path where the .app and .ipa is located at on the phone
+   * @param {Object} clientOptions The extra options that wants to be passed to the installd
+   * @param {number} timeout [60000] The timeout between messages received from the phone as status updates
+   */
+  async upgradeApplication (path, clientOptions = {}, timeout = 60000) {
+    const request = {
+      Command: 'Upgrade',
       PackagePath: path,
       ClientOptions: clientOptions
     };


### PR DESCRIPTION
installd service has different commands to install and to upgrade an app. I've added the latter to the toolset. See https://github.com/tmothy20013/libimobiledevice-master/blob/ecd89b42021cf6f7efe9ad271b3bddc7dd4b281e/src/installation_proxy.c for more details.