### PR TITLE
feat: extract get device values

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ More information can be found at the links below:
 - `utilities.getOSVersion`
 - `utilities.getDeviceTime`
 - `utilities.getDeviceName`
+- `utilities.getAllDeviceValues`
 - `utilities.startLockdownSession`
 - `utilities.connectPort`
 - `utilities.connectPortSSL`

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ More information can be found at the links below:
 - `utilities.getOSVersion`
 - `utilities.getDeviceTime`
 - `utilities.getDeviceName`
-- `utilities.getAllDeviceValues`
+- `utilities.getDeviceValues`
 - `utilities.startLockdownSession`
 - `utilities.connectPort`
 - `utilities.connectPortSSL`

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ More information can be found at the links below:
 - `utilities.getOSVersion`
 - `utilities.getDeviceTime`
 - `utilities.getDeviceName`
-- `utilities.getDeviceValues`
+- `utilities.getDeviceInfo`
 - `utilities.startLockdownSession`
 - `utilities.connectPort`
 - `utilities.connectPortSSL`

--- a/lib/utilities.js
+++ b/lib/utilities.js
@@ -74,6 +74,55 @@ async function getDeviceName (udid, socket = null) {
 }
 
 /**
+ * Returns all available device values
+ * @param {string} udid Device UDID
+ * @param {?net.Socket} socket the socket of usbmuxd. It will default to /var/run/usbmuxd if it is not passed
+ * @returns {object} Returns available default device values via lockdown.
+ * e.g.
+ * {
+ *   "BasebandCertId"=>3840149528,
+ *   "BasebandKeyHashInformation"=>
+ *     {"AKeyStatus"=>2,
+ *     "SKeyHash"=>{
+ *       "type"=>"Buffer",
+ *       "data"=>[187, 239, ....]},
+ *     "SKeyStatus"=>0},
+ *   "BasebandSerialNumber"=>{"type"=>"Buffer", "data"=>[...]},
+ *   "BasebandVersion"=>"11.01.02",
+ *   "BoardId"=>2,
+ *   "BuildVersion"=>"19C56",
+ *   "CPUArchitecture"=>"arm64",
+ *   "ChipID"=>32768,
+ *   "DeviceClass"=>"iPhone",
+ *   "DeviceColor"=>"#c8caca",
+ *   "DeviceName"=>"kazu",
+ *   "DieID"=>1111111111111,
+ *   "HardwareModel"=>"N69uAP",
+ *   "HasSiDP"=>true,
+ *   "PartitionType"=>"GUID_partition_scheme",
+ *   "ProductName"=>"iPhone OS",
+ *   "ProductType"=>"iPhone8,4",
+ *   "ProductVersion"=>"15.2",
+ *   "ProductionSOC"=>true,
+ *   "ProtocolVersion"=>"2",
+ *   "SupportedDeviceFamilies"=>[1],
+ *   "TelephonyCapability"=>true,
+ *   "UniqueChipID"=>1111111111111,
+ *   "UniqueDeviceID"=>"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+ *   "WiFiAddress"=>"00:00:00:00:00:00"
+ * }
+ */
+async function getAllDeviceValues (udid, socket = null) {
+  const usbmux = new Usbmux(socket || await getDefaultSocket());
+  try {
+    const lockdown = await usbmux.connectLockdown(udid);
+    return await lockdown.getValue();
+  } finally {
+    usbmux.close();
+  }
+}
+
+/**
  * @typedef {Object} DeviceTime
  *
  * @property {number} timestamp Unix timestamp in seconds since 1970-01-01T00:00:00Z
@@ -179,5 +228,5 @@ async function connectPort (udid, port, socket = null) {
 
 export {
   getConnectedDevices, getOSVersion, getDeviceName, getDeviceTime,
-  startLockdownSession, connectPort, connectPortSSL,
+  startLockdownSession, connectPort, connectPortSSL, getAllDeviceValues
 };

--- a/lib/utilities.js
+++ b/lib/utilities.js
@@ -112,7 +112,7 @@ async function getDeviceName (udid, socket = null) {
  *   "WiFiAddress"=>"00:00:00:00:00:00"
  * }
  */
-async function getDeviceValues (udid, socket = null) {
+async function getDeviceInfo (udid, socket = null) {
   const usbmux = new Usbmux(socket || await getDefaultSocket());
   try {
     const lockdown = await usbmux.connectLockdown(udid);
@@ -228,5 +228,5 @@ async function connectPort (udid, port, socket = null) {
 
 export {
   getConnectedDevices, getOSVersion, getDeviceName, getDeviceTime,
-  startLockdownSession, connectPort, connectPortSSL, getDeviceValues
+  startLockdownSession, connectPort, connectPortSSL, getDeviceInfo
 };

--- a/lib/utilities.js
+++ b/lib/utilities.js
@@ -112,7 +112,7 @@ async function getDeviceName (udid, socket = null) {
  *   "WiFiAddress"=>"00:00:00:00:00:00"
  * }
  */
-async function getAllDeviceValues (udid, socket = null) {
+async function getDeviceValues (udid, socket = null) {
   const usbmux = new Usbmux(socket || await getDefaultSocket());
   try {
     const lockdown = await usbmux.connectLockdown(udid);
@@ -228,5 +228,5 @@ async function connectPort (udid, port, socket = null) {
 
 export {
   getConnectedDevices, getOSVersion, getDeviceName, getDeviceTime,
-  startLockdownSession, connectPort, connectPortSSL, getAllDeviceValues
+  startLockdownSession, connectPort, connectPortSSL, getDeviceValues
 };


### PR DESCRIPTION
No arg of `getValue` returns all of the available default values.
This data helps to get device info for debugging etc.