### PR TITLE
fix: SSL. Node.js v17 upgraded to OpenSSL 3.0, TLS 1.0 and 1.1 no longer working at the default security level of 1

### DIFF
--- a/lib/ssl-helper.js
+++ b/lib/ssl-helper.js
@@ -2,7 +2,6 @@ import tls from 'tls';
 import net from 'net';
 import B from 'bluebird';
 
-const TLS_VERSION = 'TLSv1_method';
 const HANDSHAKE_TIMEOUT_MS = 10000;
 
 function upgradeToSSL (socket, key, cert) {
@@ -10,8 +9,7 @@ function upgradeToSSL (socket, key, cert) {
     rejectUnauthorized: false,
     secureContext: tls.createSecureContext({
       key,
-      cert,
-      secureProtocol: TLS_VERSION
+      cert
     })
   });
 }
@@ -28,8 +26,7 @@ async function enableSSLHandshakeOnly (socket, key, cert) {
     socket,
     secureContext: tls.createSecureContext({
       key,
-      cert,
-      secureProtocol: TLS_VERSION
+      cert
     }),
     rejectUnauthorized: false,
   });


### PR DESCRIPTION
iOS does not support TLS 1.0 anymore, and `secureProtocol` is Legacy mechanism to select the TLS protocol version to use, just use the default tls.DEFAULT_MIN_VERSION and tls.DEFAULT_MAX_VERSION