### PR TITLE
[wip]Add testmanagerd service to start WDA process

### DIFF
--- a/lib/instrument/index.js
+++ b/lib/instrument/index.js
@@ -187,4 +187,4 @@ class InstrumentService extends BaseServiceSocket {
   }
 }
 
-export { InstrumentService, INSTRUMENT_SERVICE_NAME_VERSION_14, INSTRUMENT_SERVICE_NAME };
+export { InstrumentService, INSTRUMENT_SERVICE_NAME_VERSION_14, INSTRUMENT_SERVICE_NAME, defaultDict };

--- a/lib/services.js
+++ b/lib/services.js
@@ -10,9 +10,11 @@ import { InstrumentService, INSTRUMENT_SERVICE_NAME_VERSION_14, INSTRUMENT_SERVI
 import { MCInstallProxyService, MC_INSTALL_SERVICE_NAME} from './mcinstall';
 import PlistService from './plist-service';
 import semver from 'semver';
+import { TestmanagerdService, TESTMANAGERD_SERVICE_NAME, TESTMANAGERD_SERVICE_NAME_VERSION_14 } from './testmanagerd';
 
 const CRASH_LOG_SERVICE_NAME = 'com.apple.crashreportcopymobile';
 const INSTRUMENT_HANDSHAKE_VERSION = 14;
+const TESTMANAGERD_HANDSHAKE_VERSION = 14;
 
 async function startSyslogService (udid, opts = {}) {
   const socket = await startService(udid, SYSLOG_SERVICE_NAME, opts.socket);
@@ -92,6 +94,15 @@ async function startInstrumentService (udid, opts = {}) {
   );
 }
 
+async function startTestmanagerdService (udid, opts = {}) {
+  const osVersion = opts.osVersion || await getOSVersion(udid, opts.socket);
+  return new TestmanagerdService(
+  parseInt(osVersion.split('.')[0], 10) < TESTMANAGERD_HANDSHAKE_VERSION
+    ? await startService(udid, TESTMANAGERD_SERVICE_NAME, opts.socket, true)
+    : await startService(udid, TESTMANAGERD_SERVICE_NAME_VERSION_14, opts.socket)
+  );
+}
+
 async function startMCInstallService (udid, opts = {}) {
   const socket = await startService(udid, MC_INSTALL_SERVICE_NAME, opts.socket);
   return new MCInstallProxyService(new PlistService(socket));
@@ -115,5 +126,6 @@ export {
   startSyslogService, startWebInspectorService,
   startInstallationProxyService, startSimulateLocationService,
   startAfcService, startCrashLogService, startNotificationProxyService,
-  startHouseArrestService, startInstrumentService, startMCInstallService
+  startHouseArrestService, startInstrumentService, startMCInstallService,
+  startTestmanagerdService
 };

--- a/lib/testmanagerd/index.js
+++ b/lib/testmanagerd/index.js
@@ -1,0 +1,168 @@
+
+import {BaseServiceSocket} from '../base-service';
+import {DTXMessage, FLAG_TYPES} from '../instrument/headers';
+import {DTXEncoder} from '../instrument/transformer/dtx-encode';
+import {DTXDecoder} from '../instrument/transformer/dtx-decode';
+import events from 'events';
+import _ from 'lodash';
+import {waitForCondition} from 'asyncbox';
+
+const CHECK_FREQ_MS = 500;
+const WAIT_REPLY_TIME_MS = 10000;
+const EMPTY_MESSAGE_SIZE = 16;
+const CHANNEL_CANCELED = '_channelCanceled';
+const CHANNEL_OFFSET = 2 ** 32;
+
+const TESTMANAGERD_SERVICE_NAME_VERSION_14 = 'com.apple.testmanagerd.lockdown.secure';
+const TESTMANAGERD_SERVICE_NAME = 'com.apple.testmanagerd.lockdown';
+
+function defaultDict (createValue) {
+  return new Proxy(Object.create(null), {
+    get (storage, property) {
+      if (!(property in storage)) {
+        storage[property] = createValue(property);
+      }
+      return storage[property];
+    }
+  });
+}
+
+class TestmanagerdService extends BaseServiceSocket {
+  constructor (socketClient, event) {
+    super(socketClient);
+    this._undefinedCallback = event;
+    this._callbacks = new events.EventEmitter();
+    this._channelCallbacks = new events.EventEmitter();
+    this._replyQueues = defaultDict(() => []);
+    this._channels = {};
+    this._nextIdentifier = 1;
+    this._encoder = new DTXEncoder();
+    this._encoder.pipe(this._socketClient);
+    this._assignClientFailureHandlers(this._encoder);
+    this._decoder = new DTXDecoder();
+    this._socketClient.pipe(this._decoder);
+    this._decoder.on('data', this._handleData.bind(this));
+  }
+
+  /**
+   * If the selector is registered, The message of the selector event will be returned. refer to this._handleData
+   * @param {string} selector  Listen for return DTXMessage.selector data
+   * @param {DTXCallback} event
+   */
+  registerSelectorCallback (selector, event) {
+    this._callbacks.addListener(selector, event);
+  }
+
+  /**
+   * If the event is registered, all unregistered messages will be returned to event. refer to this._handleData
+   * @param {DTXCallback} event
+   */
+  registerUndefinedCallback (event) {
+    this._undefinedCallback = event;
+  }
+
+  /**
+   * If the event is registered, this channel {CHANNEL} messages will be returned to event. refer to this._handleData
+   * It's actually listening for int channelCode. In this._channel object to record channel key and int value
+   * @param {string} channel instruments service channel e.g: INSTRUMENT_CHANNEL.DEVICE_INFO.
+   * @param {DTXCallback} event
+   */
+  async registerChannelCallback (channel, event) {
+    const channelId = await this.makeChannel(channel);
+    this._channelCallbacks.addListener(channelId, event);
+  }
+
+  /**
+   * Create a service channel, data transmission of the service will use this channelCode
+   * @param {string} channel  instruments service channel e.g: INSTRUMENT_CHANNEL.DEVICE_INFO
+   * @returns {Promise<number|*>} instruments service channel code for data transmission
+   */
+  async makeChannel (channel) {
+    if (channel in this._channels) {
+      return this._channels[channel];
+    }
+    const channelCode = Object.keys(this._channels).length + 1;
+    await this._callChannel(true, 0, '_requestChannelWithCode:identifier:', channelCode, channel);
+    this._channels[channel] = channelCode;
+    return channelCode;
+  }
+
+  /**
+   * In general, we call this method to start the instrument dtx service
+   * @param {string} channel instrument dtx service e.g: INSTRUMENT_CHANNEL.DEVICE_INFO
+   * @param {string} selector instrument service method name (reflection calls)
+   * @param {...any} auxiliaries parameters required by selector
+   * @returns {Promise<DTXMessage>}
+   * example：
+   * TestmanagerdService.callChannel(INSTRUMENT_CHANNEL.PROCESS_CONTROL,
+        'launchSuspendedProcessWithDevicePath:bundleIdentifier:environment:arguments:options:', '',
+        bundleID, {}, [], {'StartSuspendedKey': 0, 'KillExisting': 1}
+   */
+  async callChannel (channel, selector, ...auxiliaries) {
+    const channelCode = await this.makeChannel(channel);
+    return await this._callChannel(true, channelCode, selector, ...auxiliaries);
+  }
+
+  async _callChannel (sync, channelCode, selector, ...auxiliaries) {
+    const identifier = this._nextIdentifier;
+    this._encoder.write({sync, channelCode, selector, auxiliaries, identifier});
+    ++this._nextIdentifier;
+    if (sync) {
+      try {
+        return await waitForCondition(() => {
+          const queue = this._replyQueues[identifier];
+          const data = queue.shift();
+          if (!_.isUndefined(data)) {
+            return data;
+          }
+        }, {waitMs: WAIT_REPLY_TIME_MS, intervalMs: CHECK_FREQ_MS, error: 'reply channel data timeout'});
+      } catch (err) {
+        this.close();
+        throw new Error(err);
+      }
+    }
+  }
+
+  /**
+   * Handling registered asynchronous message callbacks
+   * @param {DTXMessage} data
+   * @private
+   */
+  _handleData (data) {
+    if (_.includes(data.selector, CHANNEL_CANCELED)) {
+      this.close();
+    }
+    if (data.conversationIndex === 1) {
+      this._replyQueues[data.identifier].push(data);
+    } else if (this._channelCallbacks.listenerCount(CHANNEL_OFFSET - data.channelCode) > 0) {
+      this._channelCallbacks.emit(CHANNEL_OFFSET - data.channelCode, data);
+    } else {
+      const selector = data.selector;
+      if (_.isString(selector) && this._callbacks.listenerCount(selector) > 0) {
+        this._callbacks.emit(selector, data);
+      } else if (this._undefinedCallback) {
+        this._undefinedCallback(data);
+      }
+      if (data.expectsReply) {
+        this._replyAck(data);
+      }
+    }
+  }
+
+  /**
+   * return a empty ack message
+   * @param {DTXMessage} data
+   */
+  _replyAck (data) {
+    const reply = new DTXMessage({
+      identifier: data.identifier,
+      channelCode: data.channelCode,
+      selector: Buffer.alloc(EMPTY_MESSAGE_SIZE),
+      conversationIndex: data.conversationIndex + 1,
+      flags: FLAG_TYPES.reply
+    });
+    this._socketClient.write(reply.build());
+  }
+}
+
+export { TestmanagerdService, TESTMANAGERD_SERVICE_NAME_VERSION_14, TESTMANAGERD_SERVICE_NAME };

--- a/lib/testmanagerd/index.js
+++ b/lib/testmanagerd/index.js
@@ -3,6 +3,7 @@ import {BaseServiceSocket} from '../base-service';
 import {DTXMessage, FLAG_TYPES} from '../instrument/headers';
 import {DTXEncoder} from '../instrument/transformer/dtx-encode';
 import {DTXDecoder} from '../instrument/transformer/dtx-decode';
+import {defaultDict} from '../instrument';
 import events from 'events';
 import _ from 'lodash';
 import {waitForCondition} from 'asyncbox';
@@ -16,16 +17,9 @@ const CHANNEL_OFFSET = 2 ** 32;
 const TESTMANAGERD_SERVICE_NAME_VERSION_14 = 'com.apple.testmanagerd.lockdown.secure';
 const TESTMANAGERD_SERVICE_NAME = 'com.apple.testmanagerd.lockdown';
 
-function defaultDict (createValue) {
-  return new Proxy(Object.create(null), {
-    get (storage, property) {
-      if (!(property in storage)) {
-        storage[property] = createValue(property);
-      }
-      return storage[property];
-    }
-  });
-}
+const TESTMANAGERD_CHANNEL = Object.freeze({
+  DAEMON_CONNECTION_INTERFACE: 'dtxproxy:XCTestManager_IDEInterface:XCTestManager_DaemonConnectionInterface',
+});
 
 class TestmanagerdService extends BaseServiceSocket {
   constructor (socketClient, event) {
@@ -64,7 +58,7 @@ class TestmanagerdService extends BaseServiceSocket {
   /**
    * If the event is registered, this channel {CHANNEL} messages will be returned to event. refer to this._handleData
    * It's actually listening for int channelCode. In this._channel object to record channel key and int value
-   * @param {string} channel instruments service channel e.g: INSTRUMENT_CHANNEL.DEVICE_INFO.
+   * @param {string} channel testmanagerd service channel e.g: TESTMANAGERD_CHANNEL.DAEMON_CONNECTION_INTERFACE.
    * @param {DTXCallback} event
    */
   async registerChannelCallback (channel, event) {
@@ -74,8 +68,8 @@ class TestmanagerdService extends BaseServiceSocket {
 
   /**
    * Create a service channel, data transmission of the service will use this channelCode
-   * @param {string} channel  instruments service channel e.g: INSTRUMENT_CHANNEL.DEVICE_INFO
-   * @returns {Promise<number|*>} instruments service channel code for data transmission
+   * @param {string} channel  testmanagerd service channel e.g: TESTMANAGERD_CHANNEL.DAEMON_CONNECTION_INTERFACE
+   * @returns {Promise<number|*>} testmanagerd service channel code for data transmission
    */
   async makeChannel (channel) {
     if (channel in this._channels) {
@@ -88,13 +82,13 @@ class TestmanagerdService extends BaseServiceSocket {
   }
 
   /**
-   * In general, we call this method to start the instrument dtx service
-   * @param {string} channel instrument dtx service e.g: INSTRUMENT_CHANNEL.DEVICE_INFO
-   * @param {string} selector instrument service method name (reflection calls)
+   * In general, we call this method to start the testmanagerd dtx service
+   * @param {string} channel testmanagerd dtx service e.g: TESTMANAGERD_CHANNEL.DAEMON_CONNECTION_INTERFACETESTMANAGERD_CHANNEL.DAEMON_CONNECTION_INTERFACE
+   * @param {string} selector testmanagerd service method name (reflection calls)
    * @param {...any} auxiliaries parameters required by selector
    * @returns {Promise<DTXMessage>}
    * example：
-   * TestmanagerdService.callChannel(INSTRUMENT_CHANNEL.PROCESS_CONTROL,
+   * TestmanagerdService.callChannel(TESTMANAGERD_CHANNEL.DAEMON_CONNECTION_INTERFACE,
         'launchSuspendedProcessWithDevicePath:bundleIdentifier:environment:arguments:options:', '',
         bundleID, {}, [], {'StartSuspendedKey': 0, 'KillExisting': 1}
    */
@@ -165,4 +159,4 @@ class TestmanagerdService extends BaseServiceSocket {
   }
 }
 
-export { TestmanagerdService, TESTMANAGERD_SERVICE_NAME_VERSION_14, TESTMANAGERD_SERVICE_NAME };
+export { TestmanagerdService, TESTMANAGERD_SERVICE_NAME_VERSION_14, TESTMANAGERD_SERVICE_NAME, TESTMANAGERD_CHANNEL };


### PR DESCRIPTION
Completely wip.

I wonder we can start WDA process via appium-ios-device like current idb command.
Then, we can provide an option to skip starting WDA via xcodebuild.

Referencing https://github.com/YueChen-C/py-ios-device/blob/71267a1ac472db53fa84497312f0a4cdc0fdee17/ios_device/cli/base.py#L492 and instruments implementation.