### PR TITLE
Fix buffer out of bounds on appending signed long value to DTXMessage…

### DIFF
--- a/lib/instrument/headers.js
+++ b/lib/instrument/headers.js
@@ -265,9 +265,9 @@ class DTXMessageAuxBuffer {
    */
   appendSignedLong (value) {
     const buf = Buffer.alloc(16);
-    this._buf.writeUInt32LE(DTX_AUXILIARY_MAGIC, 0);
-    this._buf.writeUInt32LE(6, 4);
-    this._buf.writeBigInt64LE(value, 8);
+    buf.writeUInt32LE(DTX_AUXILIARY_MAGIC, 0);
+    buf.writeUInt32LE(6, 4);
+    buf.writeBigInt64LE(value, 8);
     this._buf = Buffer.concat([this._buf, buf]);
   }
 


### PR DESCRIPTION
…AuxBuffer

Origin code use this._buf.write... which causes RangeError [ERR_BUFFER_OUT_OF_BOUNDS]: Attempt to access memory outside buffer bounds