### PR TITLE
feat: Add ImageMounterService and auto fetch developer image if start service failed with 'InvalidService'

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ When using a higher version of iOS devices with a lower version of Xcode or othe
 
 These operations are very cumbersome. Fortunately there are many repositories of these developer images in the open source community. The folders mentioned in the above process are zipped and uploaded into open source repositories according to different versions. You can also make your own mirror repository on GitHub in a similar way. With `services.startImageMounterService` and `utilities.fetchImageFromGithubRepo`, you can automate the whole process cross-platform.
 
-As an example, assuming we are using a repo from `https://github/example/iOSDeviceSupport`. All the zip file is inside `DeviceSupportFiles/iOS` folder of root. We can check mount status and download and mount using following code:
+As an example, assuming we are using a repo from `https://github/example/iOSDeviceSupport`. All the .zip files are inside `DeviceSupportFiles/iOS` folder of root. We can check the mount status, download and mount the image using following code:
 
 ```js
 import { services, utilities } from 'appium-ios-device';
@@ -99,7 +99,7 @@ async function checkAndMountDeveloperImage(udid) {
       const downloadedImagePath = await fetchImageFromGithubRepo(udid, repoOpts);
       if (!_.isEmpty(downloadedImagePath)) {
         const {developerImage, developerImageSignature} = downloadedImagePath;
-        imageMountService.mount(developerImage, developerImageSignature);
+        await imageMountService.mount(developerImage, developerImageSignature);
       }
     }
   } catch(e) {

--- a/README.md
+++ b/README.md
@@ -72,9 +72,10 @@ When using a higher version of iOS devices with a lower version of Xcode or othe
   1. Download .dmg file with new Xcode(sometimes beta version is needed) from [Apple Developer Downloads Page](https://developer.apple.com/download/more/).
   2. Unarchive new Xcode from .dmg file without replacing old one.
   3. Find the folder named after the target iOS version in `(New Xcode.app)/Contents/Developer/Platforms/iPhoneOS.platform/DeviceSupport`. A `DeveloperDiskImage.dmg` and a `DeveloperDiskImage.dmg.signature` should be inside that folder.
-  4. Copy the folder you found from last step and paste to `(Old Xcode.app)/Contents/Developer/Platforms/iPhoneOS.platform/DeviceSupport`
-  5. Restart your old Xcode and reconnect your devices, wait for a while until the "preparing device for development" prompt disappears.
-  6. You can also mount this image using `ideviceimagemounter` binary file compiled by [libimobiledevice](https://github.com/libimobiledevice/libimobiledevice) project on your operating system.
+  4. Copy the folder you found from last step and paste to `(Old Xcode.app)/Contents/Developer/Platforms/iPhoneOS.platform/DeviceSupport`.
+  5. The operations in the above two steps are also applicable to platforms other than the iPhone. e.g. the folder for tvOS is `(Xcode.app)/Contents/Developer/Platforms/AppleTVOS.platform/DeviceSupport`.
+  6. Restart your old Xcode and reconnect your devices, wait for a while until the "preparing device for development" prompt disappears.
+  7. You can also mount this image using `ideviceimagemounter` binary file compiled by [libimobiledevice](https://github.com/libimobiledevice/libimobiledevice) project on your operating system.
 
 These operations are very cumbersome. Fortunately there are many repositories of these developer images in the open source community. The folders mentioned in the above process are zipped and uploaded into open source repositories according to different versions. You can also make your own mirror repository on GitHub in a similar way. With `services.startImageMounterService` and `utilities.fetchImageFromGithubRepo`, you can automate the whole process cross-platform.
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ This module should be used over the `utilities` and `services` modules or export
 * `utilities.startLockdownSession`
 * `utilities.connectPort`
 * `utilities.connectPortSSL`
-* `utilities.mountDeveloperImage`
+* `utilities.fetchImageFromGithubRepo`
 * `services.startSyslogService`
 * `services.startWebInspectorService`
 * `services.startInstallationProxyService`
@@ -64,6 +64,50 @@ This class simulates the procedure which Xcode uses to invoke xctests.
     * **Throws**: If xctest bundle id invalid or not installed.
   * `xctest.stop()`
     * Stop xctest process.
+
+### Mount Developer Image
+
+When using a higher version of iOS devices with a lower version of Xcode or other non-macOS operating systems, most of the functions in `services` or `Xctest` may not be available because the developer image is not mounted. Sometimes it can be solved automatically by opening Xcode and waiting for a while. But more often you need to manually download and mount the developer image as follows：
+
+  1. Download .dmg file with new Xcode(sometimes beta version is needed) from [Apple Developer Downloads Page](https://developer.apple.com/download/more/).
+  2. Unarchive new Xcode from .dmg file without replacing old one.
+  3. Find the folder named after the target iOS version in `(New Xcode.app)/Contents/Developer/Platforms/iPhoneOS.platform/DeviceSupport`. A `DeveloperDiskImage.dmg` and a `DeveloperDiskImage.dmg.signature` should be inside that folder.
+  4. Copy the folder you found from last step and paste to `(Old Xcode.app)/Contents/Developer/Platforms/iPhoneOS.platform/DeviceSupport`
+  5. Restart your old Xcode and reconnect your devices, wait for a while until the "preparing device for development" prompt disappears.
+  6. You can also mount this image using `ideviceimagemounter` binary file compiled by [libimobiledevice](https://github.com/libimobiledevice/libimobiledevice) project on your operating system.
+
+These operations are very cumbersome. Fortunately there are many repositories of these developer images in the open source community. The folders mentioned in the above process are zipped and uploaded into open source repositories according to different versions. You can also make your own mirror repository on GitHub in a similar way. With `services.startImageMounterService` and `utilities.fetchImageFromGithubRepo`, you can automate the whole process cross-platform.
+
+As an example, assuming we are using a repo from `https://github/example/iOSDeviceSupport`. All the zip file is inside `DeviceSupportFiles/iOS` folder of root. We can check mount status and download and mount using following code:
+
+```js
+import { services, utilities } from 'appium-ios-device';
+import _ from 'lodash';
+const { startImageMounterService } = services;
+...
+async function checkAndMountDeveloperImage(udid) {
+  const imageMountService = await startImageMounterService(udid);
+  try {
+    const mountStatus = await imageMountService.isDeveloperImageMounted();
+    if (!mountStatus) {
+      const { fetchImageFromGithubRepo } = utilities;
+      const repoOpts = {
+        githubRepo: 'example/iOSDeviceSupport',
+        subFolderList: ['DeviceSupportFiles', 'iOS']
+      }
+      const downloadedImagePath = await fetchImageFromGithubRepo(udid, repoOpts);
+      if (!_.isEmpty(downloadedImagePath)) {
+        const {developerImage, developerImageSignature} = downloadedImagePath;
+        imageMountService.mount(developerImage, developerImageSignature);
+      }
+    }
+  } catch(e) {
+    // Failed to mount, do something...
+  } finally {
+    imageMountService.close();
+  }
+}
+```
 
 ## Test
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ This module should be used over the `utilities` and `services` modules or export
 * `utilities.startLockdownSession`
 * `utilities.connectPort`
 * `utilities.connectPortSSL`
+* `utilities.mountDeveloperImage`
 * `services.startSyslogService`
 * `services.startWebInspectorService`
 * `services.startInstallationProxyService`
@@ -40,6 +41,7 @@ This module should be used over the `utilities` and `services` modules or export
 * `services.startInstrumentService`
 * `services.startTestmanagerdService`
 * `services.startMCInstallService`
+* `services.startImageMounterService`
 
 ### Classes
 

--- a/lib/base-service.js
+++ b/lib/base-service.js
@@ -2,11 +2,11 @@ class BaseServiceSocket {
   /**
    * @param {import('net').Socket} socketClient
    */
-  constructor (socketClient) {
+  constructor(socketClient) {
     this._socketClient = socketClient;
   }
 
-  _assignClientFailureHandlers (...sourceStreams) {
+  _assignClientFailureHandlers(...sourceStreams) {
     for (const evt in ['close', 'end']) {
       this._socketClient.once(evt,
         () => sourceStreams.map((s) => s.unpipe(this._socketClient)));
@@ -16,7 +16,7 @@ class BaseServiceSocket {
   /**
    * Closes the underlying socket communicating with the phone
    */
-  close () {
+  close() {
     if (!this._socketClient.destroyed) {
       this._socketClient.end();
     }
@@ -24,14 +24,17 @@ class BaseServiceSocket {
 }
 
 class BaseServicePlist {
-  constructor (plistService) {
+  /**
+   * @param {import('./plist-service').PlistService} plistService
+   */
+  constructor(plistService) {
     this._plistService = plistService;
   }
 
   /**
    * Closes the underlying socket communicating with the phone
    */
-  close () {
+  close() {
     this._plistService.close();
   }
 }

--- a/lib/imagemounter/index.js
+++ b/lib/imagemounter/index.js
@@ -1,0 +1,119 @@
+import { readFile, existsSync, lstatSync, createReadStream } from 'fs';
+import { BaseServicePlist } from '../base-service';
+import B from 'bluebird';
+import log from '../logger';
+
+const MOBILE_IMAGE_MOUNTER_SERVICE_NAME = 'com.apple.mobile.mobile_image_mounter';
+
+class ImageMounter extends BaseServicePlist {
+
+    _checkReturnError(ret) {
+        if (ret.Error) {
+            throw new Error(ret.Error);
+        }
+    }
+
+    /**
+     * Lookup for mounted images.
+     * * @param {string?} imageType Type of image, `Developer` by default.
+     * @returns {Promise<Buffer[]>} Signature of each mounted image.
+     */
+    async lookup(imageType = 'Developer') {
+        const ret = await this._plistService.sendPlistAndReceive({
+            Command: 'LookupImage',
+            ImageType: imageType
+        });
+        this._checkReturnError(ret);
+        return ret.ImageSignature || [];
+    }
+
+    /**
+     * Check if developer image is mounted.
+     */
+    async developerMounted() {
+        return (await this.lookup()).length > 0;
+    }
+
+    /**
+     * Mount image for device.
+     * @param {string} imageFilePath The file path of image.
+     * @param {string} imageSignatureFilePath The signature file path of given `DeveloperDiskImage.dmg`
+     * @param {string?} imageType Type of image, `Developer` by default.
+     */
+    async mount(imageFilePath, imageSignatureFilePath, imageType = 'Developer') {
+        //check file stats
+        if (!existsSync(imageFilePath)) {
+            throw Error(`The image file provided not exists: ${imageFilePath}`);
+        }
+        const imageFileStat = lstatSync(imageFilePath);
+        if (imageFileStat.isDirectory()) {
+            throw Error(`The given image file is expected to be a file, a directory was given: ${imageFilePath}`);
+        }
+        if (!existsSync(imageSignatureFilePath)) {
+            throw Error(`The signature file provided not exists: ${imageFilePath}`);
+        }
+        if (lstatSync(imageSignatureFilePath).isDirectory()) {
+            throw Error(`The given signature file is expected to be a file, a directory was given: ${imageFilePath}`);
+        }
+        //read signature
+        const signature = await new B((resolve, reject) => {
+            readFile(imageSignatureFilePath, (err, data) => {
+                if (err != null) {
+                    reject(err);
+                } else {
+                    resolve(data);
+                }
+            });
+        });
+        const mountedImages = await this.lookup(imageType);
+        if (mountedImages.find((mountedSignature) => signature.equals(mountedSignature))) {
+            log.info(`An image with same signature of ${imageSignatureFilePath} is mounted. Doing nothing here`);
+            return;
+        }
+        //notify device
+        const imageSize = imageFileStat.size;
+        let ret = await this._plistService.sendPlistAndReceive({
+            Command: 'ReceiveBytes',
+            ImageSignature: signature,
+            ImageSize: imageSize,
+            ImageType: imageType
+        });
+        this._checkReturnError(ret);
+        if (ret.Status !== 'ReceiveBytesAck') {
+            throw Error(`Unexpected return from ${MOBILE_IMAGE_MOUNTER_SERVICE_NAME} on sending ReceiveBytes: ${JSON.stringify(ret)}`);
+        }
+        //push image to device
+        const stream = createReadStream(imageFilePath);
+        try {
+            await new B((resolve, reject) => {
+                stream.on('data', async (data) => {
+                    await this._plistService._socketClient.write(data);
+                });
+                stream.on('end', resolve);
+                stream.on('error', reject);
+            });
+        } finally {
+            stream.close();
+        }
+        ret = await this._plistService.receivePlist();
+        this._checkReturnError(ret);
+        if (ret.Status !== 'Complete') {
+            throw Error(`Unexpected return from ${MOBILE_IMAGE_MOUNTER_SERVICE_NAME} on pushing image file: ${JSON.stringify(ret)}`);
+        }
+        //mount image
+        ret = await this._plistService.sendPlistAndReceive({
+            Command: 'MountImage',
+            ImagePath: '/private/var/mobile/Media/PublicStaging/staging.dimag',
+            ImageSignature: signature,
+            ImageType: imageType
+        });
+        if (ret.DetailedError?.includes('is already mounted at /Developer')) {
+            log.warn('DeveloperImage was mounted');
+            return;
+        }
+        this._checkReturnError(ret);
+    }
+
+}
+export { ImageMounter, MOBILE_IMAGE_MOUNTER_SERVICE_NAME };
+export default ImageMounter;

--- a/lib/imagemounter/index.js
+++ b/lib/imagemounter/index.js
@@ -1,21 +1,22 @@
-import { readFile, createReadStream } from 'fs';
+import { createReadStream } from 'fs';
 import { BaseServicePlist } from '../base-service';
 import { fs } from '@appium/support';
 import B from 'bluebird';
 import log from '../logger';
 const MOBILE_IMAGE_MOUNTER_SERVICE_NAME = 'com.apple.mobile.mobile_image_mounter';
-const { exists, lstat } = fs;
-class ImageMounter extends BaseServicePlist {
+const { exists, lstat, readFile } = fs;
 
-    _checkReturnError(ret) {
-        if (ret.Error) {
-            throw new Error(ret.Error);
-        }
+function _checkReturnError(ret) {
+    if (ret.Error) {
+        throw new Error(ret.Error);
     }
+    return ret;
+}
+class ImageMounter extends BaseServicePlist {
 
     /**
      * Lookup for mounted images.
-     * @param {string?} imageType Type of image, `Developer` by default.
+     * @param {string} imageType Type of image, `Developer` by default.
      * @returns {Promise<Buffer[]>} Signature of each mounted image.
      */
     async lookup(imageType = 'Developer') {
@@ -23,8 +24,7 @@ class ImageMounter extends BaseServicePlist {
             Command: 'LookupImage',
             ImageType: imageType
         });
-        this._checkReturnError(ret);
-        return ret.ImageSignature || [];
+        return _checkReturnError(ret).ImageSignature || [];
     }
 
     /**
@@ -38,7 +38,7 @@ class ImageMounter extends BaseServicePlist {
      * Mount image for device.
      * @param {string} imageFilePath The file path of image.
      * @param {string} imageSignatureFilePath The signature file path of given `DeveloperDiskImage.dmg`
-     * @param {string?} imageType Type of image, `Developer` by default.
+     * @param {string} imageType Type of image, `Developer` by default.
      */
     async mount(imageFilePath, imageSignatureFilePath, imageType = 'Developer') {
         //check file stats
@@ -50,21 +50,13 @@ class ImageMounter extends BaseServicePlist {
             throw new Error(`The given image file is expected to be a file, a directory was given: ${imageFilePath}`);
         }
         if (!await exists(imageSignatureFilePath)) {
-            throw new Error(`The signature file provided not exists: ${imageFilePath}`);
+            throw new Error(`The provided signature file does not exists: ${imageFilePath}`);
         }
         if ((await lstat(imageSignatureFilePath)).isDirectory()) {
             throw new Error(`The given signature file is expected to be a file, a directory was given: ${imageFilePath}`);
         }
         //read signature
-        const signature = await new B((resolve, reject) => {
-            readFile(imageSignatureFilePath, (err, data) => {
-                if (err != null) {
-                    reject(err);
-                } else {
-                    resolve(data);
-                }
-            });
-        });
+        const signature = await readFile(imageSignatureFilePath);
         const mountedImages = await this.lookup(imageType);
         if (mountedImages.find((mountedSignature) => signature.equals(mountedSignature))) {
             log.info(`An image with same signature of ${imageSignatureFilePath} is mounted. Doing nothing here`);
@@ -72,15 +64,14 @@ class ImageMounter extends BaseServicePlist {
         }
         //notify device
         const imageSize = imageFileStat.size;
-        let ret = await this._plistService.sendPlistAndReceive({
+        const receiveBytesResult = await this._plistService.sendPlistAndReceive({
             Command: 'ReceiveBytes',
             ImageSignature: signature,
             ImageSize: imageSize,
             ImageType: imageType
         });
-        this._checkReturnError(ret);
-        if (ret.Status !== 'ReceiveBytesAck') {
-            throw new Error(`Unexpected return from ${MOBILE_IMAGE_MOUNTER_SERVICE_NAME} on sending ReceiveBytes: ${JSON.stringify(ret)}`);
+        if (_checkReturnError(receiveBytesResult).Status !== 'ReceiveBytesAck') {
+            throw new Error(`Unexpected return from ${MOBILE_IMAGE_MOUNTER_SERVICE_NAME} on sending ReceiveBytes: ${JSON.stringify(receiveBytesResult)}`);
         }
         //push image to device
         const stream = createReadStream(imageFilePath);
@@ -95,25 +86,23 @@ class ImageMounter extends BaseServicePlist {
         } finally {
             stream.close();
         }
-        ret = await this._plistService.receivePlist();
-        this._checkReturnError(ret);
-        if (ret.Status !== 'Complete') {
-            throw new Error(`Unexpected return from ${MOBILE_IMAGE_MOUNTER_SERVICE_NAME} on pushing image file: ${JSON.stringify(ret)}`);
+        const pushImageResult = await this._plistService.receivePlist();
+        if (_checkReturnError(pushImageResult).Status !== 'Complete') {
+            throw new Error(`Unexpected return from ${MOBILE_IMAGE_MOUNTER_SERVICE_NAME} on pushing image file: ${JSON.stringify(pushImageResult)}`);
         }
         //mount image
-        ret = await this._plistService.sendPlistAndReceive({
+        const mountResult = await this._plistService.sendPlistAndReceive({
             Command: 'MountImage',
             ImagePath: '/private/var/mobile/Media/PublicStaging/staging.dimag',
             ImageSignature: signature,
             ImageType: imageType
         });
-        if (ret.DetailedError?.includes('is already mounted at /Developer')) {
+        if (mountResult.DetailedError?.includes('is already mounted at /Developer')) {
             log.warn('DeveloperImage was mounted');
             return;
         }
-        this._checkReturnError(ret);
+        _checkReturnError(mountResult);
     }
-
 }
 export { ImageMounter, MOBILE_IMAGE_MOUNTER_SERVICE_NAME };
 export default ImageMounter;

--- a/lib/imagemounter/index.js
+++ b/lib/imagemounter/index.js
@@ -62,8 +62,10 @@ class ImageMounter extends BaseServicePlist {
      */
     async mount(imageFilePath, imageSignatureFilePath, imageType = 'Developer') {
         //check file stats
-        const imageFileStat = await assertIsFile(imageFilePath, FILE_TYPE_IMAGE);
-        await assertIsFile(imageSignatureFilePath, FILE_TYPE_SIGNATURE);
+        const [imageFileStat] = await B.all([
+            assertIsFile(imageFilePath, FILE_TYPE_IMAGE),
+            assertIsFile(imageSignatureFilePath, FILE_TYPE_SIGNATURE)
+        ]);
         //read signature
         const signature = await readFile(imageSignatureFilePath);
         const mountedImages = await this.lookup(imageType);

--- a/lib/imagemounter/index.js
+++ b/lib/imagemounter/index.js
@@ -2,18 +2,21 @@ import { BaseServicePlist } from '../base-service';
 import { fs } from '@appium/support';
 import B from 'bluebird';
 import log from '../logger';
-const MOBILE_IMAGE_MOUNTER_SERVICE_NAME = 'com.apple.mobile.mobile_image_mounter';
 const { lstat, readFile, createReadStream } = fs;
+
+const MOBILE_IMAGE_MOUNTER_SERVICE_NAME = 'com.apple.mobile.mobile_image_mounter';
 const FILE_TYPE_IMAGE = 'image';
 const FILE_TYPE_SIGNATURE = 'signature';
-function _checkReturnError(ret) {
+
+function checkIfError(ret) {
     if (ret.Error) {
         throw new Error(ret.Error);
     }
     return ret;
 }
 
-async function _checkFileStats(filePath, fileType) {
+async function assertIsFile(filePath, fileType) {
+    /** @type {import('fs').Stats | undefined} */
     let fileStat;
     try {
         fileStat = await lstat(filePath);
@@ -41,7 +44,7 @@ class ImageMounter extends BaseServicePlist {
             Command: 'LookupImage',
             ImageType: imageType
         });
-        return _checkReturnError(ret).ImageSignature || [];
+        return checkIfError(ret).ImageSignature || [];
     }
 
     /**
@@ -59,8 +62,8 @@ class ImageMounter extends BaseServicePlist {
      */
     async mount(imageFilePath, imageSignatureFilePath, imageType = 'Developer') {
         //check file stats
-        const imageFileStat = await _checkFileStats(imageFilePath, FILE_TYPE_IMAGE);
-        await _checkFileStats(imageSignatureFilePath, FILE_TYPE_SIGNATURE);
+        const imageFileStat = await assertIsFile(imageFilePath, FILE_TYPE_IMAGE);
+        await assertIsFile(imageSignatureFilePath, FILE_TYPE_SIGNATURE);
         //read signature
         const signature = await readFile(imageSignatureFilePath);
         const mountedImages = await this.lookup(imageType);
@@ -76,7 +79,7 @@ class ImageMounter extends BaseServicePlist {
             ImageSize: imageSize,
             ImageType: imageType
         });
-        if (_checkReturnError(receiveBytesResult).Status !== 'ReceiveBytesAck') {
+        if (checkIfError(receiveBytesResult).Status !== 'ReceiveBytesAck') {
             throw new Error(`Unexpected return from ${MOBILE_IMAGE_MOUNTER_SERVICE_NAME} on sending ReceiveBytes: ${JSON.stringify(receiveBytesResult)}`);
         }
         //push image to device
@@ -97,7 +100,7 @@ class ImageMounter extends BaseServicePlist {
             stream.close();
         }
         const pushImageResult = await this._plistService.receivePlist();
-        if (_checkReturnError(pushImageResult).Status !== 'Complete') {
+        if (checkIfError(pushImageResult).Status !== 'Complete') {
             throw new Error(`Unexpected return from ${MOBILE_IMAGE_MOUNTER_SERVICE_NAME} on pushing image file: ${JSON.stringify(pushImageResult)}`);
         }
         //mount image
@@ -111,8 +114,7 @@ class ImageMounter extends BaseServicePlist {
             log.warn('DeveloperImage was mounted');
             return;
         }
-        _checkReturnError(mountResult);
+        checkIfError(mountResult);
     }
 }
 export { ImageMounter, MOBILE_IMAGE_MOUNTER_SERVICE_NAME };
-export default ImageMounter;

--- a/lib/imagemounter/index.js
+++ b/lib/imagemounter/index.js
@@ -83,11 +83,15 @@ class ImageMounter extends BaseServicePlist {
         const stream = createReadStream(imageFilePath);
         try {
             await new B((resolve, reject) => {
-                stream.on('data', async (data) => {
-                    await this._plistService._socketClient.write(data);
-                });
                 stream.on('end', resolve);
                 stream.on('error', reject);
+                stream.on('data', async (data) => {
+                    try {
+                        await this._plistService._socketClient.write(data);
+                    } catch (e) {
+                        stream.emit('error', e);
+                    }
+                });
             });
         } finally {
             stream.close();

--- a/lib/imagemounter/index.js
+++ b/lib/imagemounter/index.js
@@ -1,17 +1,34 @@
-import { createReadStream } from 'fs';
 import { BaseServicePlist } from '../base-service';
 import { fs } from '@appium/support';
 import B from 'bluebird';
 import log from '../logger';
 const MOBILE_IMAGE_MOUNTER_SERVICE_NAME = 'com.apple.mobile.mobile_image_mounter';
-const { exists, lstat, readFile } = fs;
-
+const { lstat, readFile, createReadStream } = fs;
+const FILE_TYPE_IMAGE = 'image';
+const FILE_TYPE_SIGNATURE = 'signature';
 function _checkReturnError(ret) {
     if (ret.Error) {
         throw new Error(ret.Error);
     }
     return ret;
 }
+
+async function _checkFileStats(filePath, fileType) {
+    let fileStat;
+    try {
+        fileStat = await lstat(filePath);
+    } catch (err) {
+        if (/** @type {NodeJS.ErrnoException} */(err).code === 'ENOENT') {
+            throw new Error(`The provided ${fileType} path does not exist: ${filePath}`);
+        }
+        throw err;
+    }
+    if (fileStat.isDirectory()) {
+        throw new Error(`The provided ${fileType} path is expected to be a file, but a directory was given: ${filePath}`);
+    }
+    return fileStat;
+}
+
 class ImageMounter extends BaseServicePlist {
 
     /**
@@ -42,19 +59,8 @@ class ImageMounter extends BaseServicePlist {
      */
     async mount(imageFilePath, imageSignatureFilePath, imageType = 'Developer') {
         //check file stats
-        if (!await exists(imageFilePath)) {
-            throw new Error(`The image file provided not exists: ${imageFilePath}`);
-        }
-        const imageFileStat = await lstat(imageFilePath);
-        if (imageFileStat.isDirectory()) {
-            throw new Error(`The given image file is expected to be a file, a directory was given: ${imageFilePath}`);
-        }
-        if (!await exists(imageSignatureFilePath)) {
-            throw new Error(`The provided signature file does not exists: ${imageFilePath}`);
-        }
-        if ((await lstat(imageSignatureFilePath)).isDirectory()) {
-            throw new Error(`The given signature file is expected to be a file, a directory was given: ${imageFilePath}`);
-        }
+        const imageFileStat = await _checkFileStats(imageFilePath, FILE_TYPE_IMAGE);
+        await _checkFileStats(imageSignatureFilePath, FILE_TYPE_SIGNATURE);
         //read signature
         const signature = await readFile(imageSignatureFilePath);
         const mountedImages = await this.lookup(imageType);

--- a/lib/imagemounter/index.js
+++ b/lib/imagemounter/index.js
@@ -1,10 +1,10 @@
-import { readFile, existsSync, lstatSync, createReadStream } from 'fs';
+import { readFile, createReadStream } from 'fs';
 import { BaseServicePlist } from '../base-service';
+import { fs } from '@appium/support';
 import B from 'bluebird';
 import log from '../logger';
-
 const MOBILE_IMAGE_MOUNTER_SERVICE_NAME = 'com.apple.mobile.mobile_image_mounter';
-
+const { exists, lstat } = fs;
 class ImageMounter extends BaseServicePlist {
 
     _checkReturnError(ret) {
@@ -15,7 +15,7 @@ class ImageMounter extends BaseServicePlist {
 
     /**
      * Lookup for mounted images.
-     * * @param {string?} imageType Type of image, `Developer` by default.
+     * @param {string?} imageType Type of image, `Developer` by default.
      * @returns {Promise<Buffer[]>} Signature of each mounted image.
      */
     async lookup(imageType = 'Developer') {
@@ -30,7 +30,7 @@ class ImageMounter extends BaseServicePlist {
     /**
      * Check if developer image is mounted.
      */
-    async developerMounted() {
+    async isDeveloperImageMounted() {
         return (await this.lookup()).length > 0;
     }
 
@@ -42,18 +42,18 @@ class ImageMounter extends BaseServicePlist {
      */
     async mount(imageFilePath, imageSignatureFilePath, imageType = 'Developer') {
         //check file stats
-        if (!existsSync(imageFilePath)) {
-            throw Error(`The image file provided not exists: ${imageFilePath}`);
+        if (!await exists(imageFilePath)) {
+            throw new Error(`The image file provided not exists: ${imageFilePath}`);
         }
-        const imageFileStat = lstatSync(imageFilePath);
+        const imageFileStat = await lstat(imageFilePath);
         if (imageFileStat.isDirectory()) {
-            throw Error(`The given image file is expected to be a file, a directory was given: ${imageFilePath}`);
+            throw new Error(`The given image file is expected to be a file, a directory was given: ${imageFilePath}`);
         }
-        if (!existsSync(imageSignatureFilePath)) {
-            throw Error(`The signature file provided not exists: ${imageFilePath}`);
+        if (!await exists(imageSignatureFilePath)) {
+            throw new Error(`The signature file provided not exists: ${imageFilePath}`);
         }
-        if (lstatSync(imageSignatureFilePath).isDirectory()) {
-            throw Error(`The given signature file is expected to be a file, a directory was given: ${imageFilePath}`);
+        if ((await lstat(imageSignatureFilePath)).isDirectory()) {
+            throw new Error(`The given signature file is expected to be a file, a directory was given: ${imageFilePath}`);
         }
         //read signature
         const signature = await new B((resolve, reject) => {
@@ -80,7 +80,7 @@ class ImageMounter extends BaseServicePlist {
         });
         this._checkReturnError(ret);
         if (ret.Status !== 'ReceiveBytesAck') {
-            throw Error(`Unexpected return from ${MOBILE_IMAGE_MOUNTER_SERVICE_NAME} on sending ReceiveBytes: ${JSON.stringify(ret)}`);
+            throw new Error(`Unexpected return from ${MOBILE_IMAGE_MOUNTER_SERVICE_NAME} on sending ReceiveBytes: ${JSON.stringify(ret)}`);
         }
         //push image to device
         const stream = createReadStream(imageFilePath);
@@ -98,7 +98,7 @@ class ImageMounter extends BaseServicePlist {
         ret = await this._plistService.receivePlist();
         this._checkReturnError(ret);
         if (ret.Status !== 'Complete') {
-            throw Error(`Unexpected return from ${MOBILE_IMAGE_MOUNTER_SERVICE_NAME} on pushing image file: ${JSON.stringify(ret)}`);
+            throw new Error(`Unexpected return from ${MOBILE_IMAGE_MOUNTER_SERVICE_NAME} on pushing image file: ${JSON.stringify(ret)}`);
         }
         //mount image
         ret = await this._plistService.sendPlistAndReceive({

--- a/lib/imagemounter/index.js
+++ b/lib/imagemounter/index.js
@@ -82,7 +82,8 @@ class ImageMounter extends BaseServicePlist {
             ImageType: imageType
         });
         if (checkIfError(receiveBytesResult).Status !== 'ReceiveBytesAck') {
-            throw new Error(`Unexpected return from ${MOBILE_IMAGE_MOUNTER_SERVICE_NAME} on sending ReceiveBytes: ${JSON.stringify(receiveBytesResult)}`);
+            const errMsg = `Unexpected return from ${MOBILE_IMAGE_MOUNTER_SERVICE_NAME} on sending ReceiveBytes`;
+            throw new Error(`${errMsg}: ${JSON.stringify(receiveBytesResult)}`);
         }
         //push image to device
         const stream = createReadStream(imageFilePath);
@@ -103,7 +104,8 @@ class ImageMounter extends BaseServicePlist {
         }
         const pushImageResult = await this._plistService.receivePlist();
         if (checkIfError(pushImageResult).Status !== 'Complete') {
-            throw new Error(`Unexpected return from ${MOBILE_IMAGE_MOUNTER_SERVICE_NAME} on pushing image file: ${JSON.stringify(pushImageResult)}`);
+            const errMsg = `Unexpected return from ${MOBILE_IMAGE_MOUNTER_SERVICE_NAME} on pushing image file`;
+            throw new Error(`${errMsg}: ${JSON.stringify(pushImageResult)}`);
         }
         //mount image
         const mountResult = await this._plistService.sendPlistAndReceive({
@@ -113,7 +115,7 @@ class ImageMounter extends BaseServicePlist {
             ImageType: imageType
         });
         if (mountResult.DetailedError?.includes('is already mounted at /Developer')) {
-            log.warn('DeveloperImage was mounted');
+            log.info('DeveloperImage was already mounted');
             return;
         }
         checkIfError(mountResult);

--- a/lib/imagemounter/utils/list_developer_image.js
+++ b/lib/imagemounter/utils/list_developer_image.js
@@ -3,7 +3,8 @@ import { zip, net, env, fs } from '@appium/support';
 import { join as joinPath } from 'path';
 import axios from 'axios';
 import log from '../../logger';
-const { exists, readdir, lstat, mkdir, rimraf } = fs;
+
+const { exists, readdir, mkdir, rimraf } = fs;
 /**
  * @typedef {Object} GithubTreeObject
  * @property {string} path
@@ -18,12 +19,12 @@ const { exists, readdir, lstat, mkdir, rimraf } = fs;
  * @typedef {Object} GithubTreeResponse
  * @property {string} sha
  * @property {string} url
- * @property {GithubTreeObject[]?} tree
- * @property {boolean?} truncated
- * @property {string?} node_id
- * @property {number?} size
- * @property {string?} content
- * @property {string?} base64
+ * @property {GithubTreeObject[]} [tree]
+ * @property {boolean} [truncated]
+ * @property {string} [node_id]
+ * @property {number} [size]
+ * @property {string} [content]
+ * @property {string} [base64]
  */
 
 /**
@@ -31,7 +32,7 @@ const { exists, readdir, lstat, mkdir, rimraf } = fs;
  * The image and signature files should be compressed into a zip format, and the filename should match this regular expression:
  *  `${finalVersion}(\\(([\\w_|.()])+\\))?.zip`
  * @property {string} githubRepo This should be in format of `$(group or username)/${repository}`, which contains available images.
- * @property {string[]?} subFolderList subfolder list in level order
+ * @property {string[]} [subFolderList] subfolder list in level order
  */
 const DEFAULT_IMAGE_DIR_NAME = 'iOSDeviceSupport';
 const DEVELOPER_IMAGE_FILE_NAME = 'DeveloperDiskImage.dmg';
@@ -40,7 +41,7 @@ const DEVELOPER_IMAGE_SIGNATURE_FILE_NAME = 'DeveloperDiskImage.dmg.signature';
 /**
  * Use list api to return the file list of folder.
  * @param {ImageFromGithubRepo} githubImageOption
- * @returns {GithubTreeObject[]} file list under target folder
+ * @returns {Promise<GithubTreeObject[] | undefined>} file list under target folder
  */
 async function listGithubImageList(githubImageOption) {
     const { githubRepo, subFolderList = [] } = githubImageOption;
@@ -49,9 +50,8 @@ async function listGithubImageList(githubImageOption) {
     const fileList = [];
     let curUrl = initialUrl;
     /**
-     * @type {GithubTreeObject[]?}
+     * @type {GithubTreeObject[]|undefined}
      */
-    let ret = null;
     for (let i = 0; i <= subFolderList.length; i++) {
         const res = await axios.get(curUrl);
         /**
@@ -63,8 +63,7 @@ async function listGithubImageList(githubImageOption) {
             throw new Error(`Failed on looking up ${fileList.join('/')} under ${repoUrl}: ${JSON.stringify(body)}`);
         }
         if (i === subFolderList.length) {
-            ret = treeList;
-            break;
+            return treeList;
         }
         const entry = subFolderList[i];
         const nextItem = _.find(treeList, (item) => item.path === entry);
@@ -77,30 +76,27 @@ async function listGithubImageList(githubImageOption) {
         fileList.push(entry);
         curUrl = nextItem.url;
     }
-    return ret;
 }
 
 /**
  * Find `DeveloperDiskImage.dmg` recursively under folder and subfolder.
  * @param {string} entry current folder
- * @returns {string | undefined} parent folder of `DeveloperDiskImage.dmg` or `undefined` if no such file exists
+ * @returns {Promise<string | undefined>} parent folder of `DeveloperDiskImage.dmg` or `undefined` if no such file exists
  */
 async function findDeveloperImageFromDirectory(entry) {
-    const fileList = await readdir(entry);
+    const fileList = await readdir(entry, { withFileTypes: true });
     for (const subEntry of fileList) {
-        const fullPath = joinPath(entry, subEntry);
-        const statResult = await lstat(fullPath);
-        if (subEntry === DEVELOPER_IMAGE_FILE_NAME && statResult.isFile()) {
+        if (subEntry.name === DEVELOPER_IMAGE_FILE_NAME && subEntry.isFile()) {
             return entry;
         }
-        if (statResult.isDirectory()) {
+        if (subEntry.isDirectory()) {
+            const fullPath = joinPath(entry, subEntry.name);
             const subFolderResult = await findDeveloperImageFromDirectory(fullPath);
             if (subFolderResult) {
                 return subFolderResult;
             }
         }
     }
-    return undefined;
 }
 
 /**
@@ -130,7 +126,8 @@ async function findDeveloperImage(version, githubImageOption) {
         await searchAndDownloadDeveloperImageFromGithub(finalVersion, fullDownloadPath, githubImageOption);
     }
     const decompressPath = joinPath(DEFAULT_IMAGE_DIR, finalVersion);
-    let developerImageParentFolder = null;
+    /** @type {string | undefined} */
+    let developerImageParentFolder;
     if (await exists(decompressPath)) {
         developerImageParentFolder = await findDeveloperImageFromDirectory(decompressPath);
     }
@@ -147,17 +144,25 @@ async function findDeveloperImage(version, githubImageOption) {
     };
 }
 
+/**
+ *
+ * @param {string} finalVersion
+ * @param {string} fullDownloadPath
+ * @param {ImageFromGithubRepo} githubImageOption
+ */
 async function searchAndDownloadDeveloperImageFromGithub(finalVersion, fullDownloadPath, githubImageOption) {
-    const fileNameRegExp = new RegExp(`${finalVersion}(\\(([\\w_|.()])+\\))?.zip`);
-    const { githubRepo, subFolderList } = githubImageOption;
-    let fileUrl = null;
+    const fileNameRegExp = new RegExp(`${_.escapeRegExp(finalVersion)}(\\(([\\w_|.()])+\\))?.zip`);
+    const { githubRepo, subFolderList = [] } = githubImageOption;
+    /** @type {string | undefined} */
+    let fileUrl;
     const fileList = await listGithubImageList(githubImageOption);
     if (!fileList) {
         throw new Error(`Failed to list https://github.com/${githubRepo}`);;
     }
     const targetFile = _.find(fileList, (item) => fileNameRegExp.test(item.path));
+    const subFolderPath = `${subFolderList.length > 0 ? '/' : ''}${subFolderList.join('/')}${subFolderList.length > 0 ? '/' : ''}`;
     if (targetFile) {
-        fileUrl = `https://raw.githubusercontent.com/${githubRepo}/master/${subFolderList.join('/')}/${targetFile.path}`;
+        fileUrl = `https://raw.githubusercontent.com/${githubRepo}/master${subFolderPath}${targetFile.path}`;
     }
     if (!fileUrl) {
         throw new Error(`Failed to get developer image for iOS ${finalVersion}`);

--- a/lib/imagemounter/utils/list_developer_image.js
+++ b/lib/imagemounter/utils/list_developer_image.js
@@ -1,10 +1,9 @@
 import _ from 'lodash';
-import { zip, net } from '@appium/support';
-import { homedir } from 'os';
+import { zip, net, env, fs } from '@appium/support';
 import { join as joinPath } from 'path';
-import fetch from 'node-fetch';
-import { readdirSync, lstatSync, existsSync, mkdirSync, unlinkSync } from 'fs';
+import axios from 'axios';
 import log from '../../logger';
+const { exists, readdir, lstat, mkdir, unlink } = fs;
 /**
  * @typedef {Object} GithubTreeObject
  * @property {string} path
@@ -42,8 +41,7 @@ const AVAILABLE_REPOS = [
         subFolderList: ['DeviceSupport']
     }
 ];
-const HOME_DIR = homedir();
-const DEFAULT_IMAGE_DIR = joinPath(HOME_DIR, '.appium', 'iOSDeviceSupport');
+const DEFAULT_IMAGE_DIR_NAME = 'iOSDeviceSupport';
 const DEVELOPER_IMAGE_FILE_NAME = 'DeveloperDiskImage.dmg';
 const DEVELOPER_IMAGE_SIGNATURE_FILE_NAME = 'DeveloperDiskImage.dmg.signature';
 
@@ -51,8 +49,8 @@ const DEVELOPER_IMAGE_SIGNATURE_FILE_NAME = 'DeveloperDiskImage.dmg.signature';
  * Use list api to return the file list of folder.
  * @param {string} user github user
  * @param {string} name the name of repository
- * @param subFolderList subfolder list in level order
- * @returns {GithubTreeObject?} file list under target folder
+ * @param {string[]} subFolderList subfolder list in level order
+ * @returns {GithubTreeObject[]?} file list under target folder
  */
 async function listGithubImageList(user, name, subFolderList = []) {
     const initialUrl = `https://api.github.com/repos/${user}/${name}/git/trees/master`;
@@ -64,24 +62,26 @@ async function listGithubImageList(user, name, subFolderList = []) {
      */
     let ret = null;
     for (let i = 0; i <= subFolderList.length; i++) {
+        const res = await axios.get(curUrl);
         /**
          * @type {GithubTreeResponse}
          */
-        const body = await fetch(curUrl).then((r) => r.json());
-        if (!body.tree) {
-            throw Error(`Failed on looking up ${fileList.join('/')} under ${repoUrl}: ${JSON.stringify(body)}`);
+        const body = res.data;
+        const treeList = body?.tree;
+        if (!treeList) {
+            throw new Error(`Failed on looking up ${fileList.join('/')} under ${repoUrl}: ${JSON.stringify(body)}`);
         }
         if (i === subFolderList.length) {
-            ret = body.tree;
+            ret = treeList;
             break;
         }
         const entry = subFolderList[i];
-        const nextItem = _.find(body.tree, (item) => item.path === entry);
+        const nextItem = _.find(treeList, (item) => item.path === entry);
         if (!nextItem) {
-            throw Error(`Unable to find ${entry} under ${fileList.join('/')} in under ${repoUrl}: ${JSON.stringify(body.tree)}`);
+            throw new Error(`Unable to find ${entry} under ${fileList.join('/')} in under ${repoUrl}: ${JSON.stringify(treeList)}`);
         }
         if (nextItem.type !== 'tree') {
-            throw Error(`${entry} under under ${fileList.join('/')} in under ${repoUrl} is expected to be a tree, got ${nextItem.type} instead.`);
+            throw new Error(`${entry} under ${fileList.join('/')} in ${repoUrl} is expected to be a tree, got ${nextItem.type} instead.`);
         }
         fileList.push(entry);
         curUrl = nextItem.url;
@@ -94,16 +94,16 @@ async function listGithubImageList(user, name, subFolderList = []) {
  * @param {string} entry current folder
  * @returns {string | undefined} parent folder of `DeveloperDiskImage.dmg` or `undefined` if no such file exists
  */
-function findDeveloperImageFromDirectory(entry) {
-    const fileList = readdirSync(entry);
+async function findDeveloperImageFromDirectory(entry) {
+    const fileList = await readdir(entry);
     for (const subEntry of fileList) {
         const fullPath = joinPath(entry, subEntry);
-        const statResult = lstatSync(fullPath);
+        const statResult = await lstat(fullPath);
         if (subEntry === DEVELOPER_IMAGE_FILE_NAME && statResult.isFile()) {
             return entry;
         }
         if (statResult.isDirectory()) {
-            const subFolderResult = findDeveloperImageFromDirectory(fullPath);
+            const subFolderResult = await findDeveloperImageFromDirectory(fullPath);
             if (subFolderResult) {
                 return subFolderResult;
             }
@@ -121,31 +121,33 @@ function findDeveloperImageFromDirectory(entry) {
 /**
  * Find developer image for certain version. If developer image does not exists,
  * this will try to find and download developer image, unzip to `~/.appium/iOSSupport/`
- * @param {string} version full version of iOS device
+ * @param {string} version full version of iOS device. The first two parts of version
+ * will be preserved when sending the request, e.g. `14.7.1` will be changed to `14.7`
  * @returns {ImagePath}
  * @throws If developer image is not found, or error while downloading or unzipping.
  */
 async function findDeveloperImage(version) {
     const finalVersion = version.split('.').splice(0, 2).join('.');
     const fileName = `${finalVersion}.zip`;
+    const DEFAULT_IMAGE_DIR = joinPath(await env.resolveAppiumHome(), DEFAULT_IMAGE_DIR_NAME);
     const fullDownloadPath = joinPath(DEFAULT_IMAGE_DIR, fileName);
-    if (!existsSync(DEFAULT_IMAGE_DIR)) {
-        mkdirSync(DEFAULT_IMAGE_DIR, { recursive: true });
+    if (!await exists(DEFAULT_IMAGE_DIR)) {
+        await mkdir(DEFAULT_IMAGE_DIR, { recursive: true });
     }
-    if (!existsSync(fullDownloadPath)) {
+    if (!await exists(fullDownloadPath)) {
         await searchAndDownloadDeveloperImageFromGithub(finalVersion, fullDownloadPath);
     }
     const decompressPath = joinPath(DEFAULT_IMAGE_DIR, finalVersion);
     let developerImageParentFolder = null;
-    if (existsSync(decompressPath)) {
-        developerImageParentFolder = findDeveloperImageFromDirectory(decompressPath);
+    if (await exists(decompressPath)) {
+        developerImageParentFolder = await findDeveloperImageFromDirectory(decompressPath);
     }
     if (!developerImageParentFolder) {
         await zip.extractAllTo(fullDownloadPath, decompressPath);
-        developerImageParentFolder = findDeveloperImageFromDirectory(decompressPath);
+        developerImageParentFolder = await findDeveloperImageFromDirectory(decompressPath);
     }
     if (!developerImageParentFolder) {
-        throw Error(`Unable to find unzipped developer image in ${decompressPath}`);
+        throw new Error(`Unable to find unzipped developer image in ${decompressPath}`);
     }
     return {
         developerImage: joinPath(developerImageParentFolder, DEVELOPER_IMAGE_FILE_NAME),
@@ -162,19 +164,19 @@ async function searchAndDownloadDeveloperImageFromGithub(finalVersion, fullDownl
             continue;
         }
         const targetFile = _.find(fileList, (item) => fileNameRegExp.test(item.path));
-        if (targetFile != null) {
+        if (targetFile) {
             fileUrl = `https://raw.githubusercontent.com/${repo.user}/${repo.name}/master/${repo.subFolderList.join('/')}/${targetFile.path}`;
             break;
         }
     }
     if (fileUrl === null) {
-        throw Error(`Failed to get developer image for iOS ${finalVersion}`);
+        throw new Error(`Failed to get developer image for iOS ${finalVersion}`);
     }
     try {
         log.info(`Downloading developer image for ${finalVersion} to ${fullDownloadPath} from ${fileUrl}`);
         await net.downloadFile(fileUrl, fullDownloadPath);
     } catch (e) {
-        unlinkSync(fullDownloadPath);
+        await unlink(fullDownloadPath);
         throw e;
     }
 }

--- a/lib/imagemounter/utils/list_developer_image.js
+++ b/lib/imagemounter/utils/list_developer_image.js
@@ -28,10 +28,11 @@ const { exists, readdir, mkdir, rimraf } = fs;
  */
 
 /**
- * @typedef {Object} ImageFromGithubRepo Option to indicate which github repo and subfolder to use to search developer image.
- * The image and signature files should be compressed into a zip format, and the filename should match this regular expression:
- *  `${finalVersion}(\\(([\\w_|.()])+\\))?.zip`
- * @property {string} githubRepo This should be in format of `$(group or username)/${repository}`, which contains available images.
+ * @typedef {Object} ImageFromGithubRepo Option to indicate which github repo and subfolder to use to search developer
+ * image. The image and signature files should be compressed into a zip format, and the filename should match this
+ * regular expression: `${finalVersion}(\\(([\\w_|.()])+\\))?.zip`
+ * @property {string} githubRepo This should be in format of `$(group or username)/${repository}`, which contains
+ * available images.
  * @property {string} branch
  * @property {string[]} [subFolderList] subfolder list in level order
  */
@@ -69,10 +70,12 @@ async function listGithubImageList(githubImageOption) {
         const entry = subFolderList[i];
         const nextItem = _.find(treeList, (item) => item.path === entry);
         if (!nextItem) {
-            throw new Error(`Unable to find ${entry} under ${fileList.join('/')} in under ${repoUrl}: ${JSON.stringify(treeList)}`);
+            const errMsg = `Unable to find ${entry} under ${fileList.join('/')} in ${repoUrl}`;
+            throw new Error(`${errMsg}: ${JSON.stringify(treeList)}`);
         }
         if (nextItem.type !== 'tree') {
-            throw new Error(`${entry} under ${fileList.join('/')} in ${repoUrl} is expected to be a tree, got ${nextItem.type} instead.`);
+            const errMsg = `${entry} under ${fileList.join('/')} in ${repoUrl} is expected to be a tree`;
+            throw new Error(`${errMsg}, got ${nextItem.type} instead.`);
         }
         fileList.push(entry);
         curUrl = nextItem.url;
@@ -82,7 +85,8 @@ async function listGithubImageList(githubImageOption) {
 /**
  * Find `DeveloperDiskImage.dmg` recursively under folder and subfolder.
  * @param {string} entry current folder
- * @returns {Promise<string | undefined>} parent folder of `DeveloperDiskImage.dmg` or `undefined` if no such file exists
+ * @returns {Promise<string | undefined>} parent folder of `DeveloperDiskImage.dmg`,
+ *  or `undefined` if no such file exists
  */
 async function findDeveloperImageFromDirectory(entry) {
     const fileList = await readdir(entry, { withFileTypes: true });
@@ -161,7 +165,8 @@ async function searchAndDownloadDeveloperImageFromGithub(finalVersion, fullDownl
         throw new Error(`Failed to list https://github.com/${githubRepo}`);;
     }
     const targetFile = _.find(fileList, (item) => fileNameRegExp.test(item.path));
-    const subFolderPath = `${subFolderList.length > 0 ? '/' : ''}${subFolderList.join('/')}${subFolderList.length > 0 ? '/' : ''}`;
+    const splitter = subFolderList.length > 0 ? '/' : '';
+    const subFolderPath = `${splitter}${subFolderList.join('/')}${splitter}`;
     if (targetFile) {
         fileUrl = `https://raw.githubusercontent.com/${githubRepo}/${branch}${subFolderPath}${targetFile.path}`;
     }

--- a/lib/imagemounter/utils/list_developer_image.js
+++ b/lib/imagemounter/utils/list_developer_image.js
@@ -3,7 +3,7 @@ import { zip, net, env, fs } from '@appium/support';
 import { join as joinPath } from 'path';
 import axios from 'axios';
 import log from '../../logger';
-const { exists, readdir, lstat, mkdir, unlink } = fs;
+const { exists, readdir, lstat, mkdir, rimraf } = fs;
 /**
  * @typedef {Object} GithubTreeObject
  * @property {string} path
@@ -26,35 +26,26 @@ const { exists, readdir, lstat, mkdir, unlink } = fs;
  * @property {string?} base64
  */
 
-const AVAILABLE_REPOS = [
-    {
-        user: 'JinjunHan',
-        name: 'iOSDeviceSupport',
-        subFolderList: ['iOSDeviceSupport']
-    }, {
-        user: 'filsv',
-        name: 'iOSDeviceSupport',
-        subFolderList: []
-    }, {
-        user: 'iGhibli',
-        name: 'iOS-DeviceSupport',
-        subFolderList: ['DeviceSupport']
-    }
-];
+/**
+ * @typedef {Object} ImageFromGithubRepo Option to indicate which github repo and subfolder to use to search developer image.
+ * The image and signature files should be compressed into a zip format, and the filename should match this regular expression:
+ *  `${finalVersion}(\\(([\\w_|.()])+\\))?.zip`
+ * @property {string} githubRepo This should be in format of `$(group or username)/${repository}`, which contains available images.
+ * @property {string[]?} subFolderList subfolder list in level order
+ */
 const DEFAULT_IMAGE_DIR_NAME = 'iOSDeviceSupport';
 const DEVELOPER_IMAGE_FILE_NAME = 'DeveloperDiskImage.dmg';
 const DEVELOPER_IMAGE_SIGNATURE_FILE_NAME = 'DeveloperDiskImage.dmg.signature';
 
 /**
  * Use list api to return the file list of folder.
- * @param {string} user github user
- * @param {string} name the name of repository
- * @param {string[]} subFolderList subfolder list in level order
- * @returns {GithubTreeObject[]?} file list under target folder
+ * @param {ImageFromGithubRepo} githubImageOption
+ * @returns {GithubTreeObject[]} file list under target folder
  */
-async function listGithubImageList(user, name, subFolderList = []) {
-    const initialUrl = `https://api.github.com/repos/${user}/${name}/git/trees/master`;
-    const repoUrl = `https://github.com/${user}/${name}/`;
+async function listGithubImageList(githubImageOption) {
+    const { githubRepo, subFolderList = [] } = githubImageOption;
+    const initialUrl = `https://api.github.com/repos/${githubRepo}/git/trees/master`;
+    const repoUrl = `https://github.com/${githubRepo}/`;
     const fileList = [];
     let curUrl = initialUrl;
     /**
@@ -120,13 +111,14 @@ async function findDeveloperImageFromDirectory(entry) {
 
 /**
  * Find developer image for certain version. If developer image does not exists,
- * this will try to find and download developer image, unzip to `~/.appium/iOSSupport/`
+ * this will try to find and download developer image, unzip to `${APPIUM_HOME}/iOSSupport/`
  * @param {string} version full version of iOS device. The first two parts of version
  * will be preserved when sending the request, e.g. `14.7.1` will be changed to `14.7`
- * @returns {ImagePath}
+ * @param {ImageFromGithubRepo} githubImageOption
+ * @returns {Promise<ImagePath>}
  * @throws If developer image is not found, or error while downloading or unzipping.
  */
-async function findDeveloperImage(version) {
+async function findDeveloperImage(version, githubImageOption) {
     const finalVersion = version.split('.').splice(0, 2).join('.');
     const fileName = `${finalVersion}.zip`;
     const DEFAULT_IMAGE_DIR = joinPath(await env.resolveAppiumHome(), DEFAULT_IMAGE_DIR_NAME);
@@ -135,7 +127,7 @@ async function findDeveloperImage(version) {
         await mkdir(DEFAULT_IMAGE_DIR, { recursive: true });
     }
     if (!await exists(fullDownloadPath)) {
-        await searchAndDownloadDeveloperImageFromGithub(finalVersion, fullDownloadPath);
+        await searchAndDownloadDeveloperImageFromGithub(finalVersion, fullDownloadPath, githubImageOption);
     }
     const decompressPath = joinPath(DEFAULT_IMAGE_DIR, finalVersion);
     let developerImageParentFolder = null;
@@ -155,28 +147,26 @@ async function findDeveloperImage(version) {
     };
 }
 
-async function searchAndDownloadDeveloperImageFromGithub(finalVersion, fullDownloadPath) {
+async function searchAndDownloadDeveloperImageFromGithub(finalVersion, fullDownloadPath, githubImageOption) {
     const fileNameRegExp = new RegExp(`${finalVersion}(\\(([\\w_|.()])+\\))?.zip`);
+    const { githubRepo, subFolderList } = githubImageOption;
     let fileUrl = null;
-    for (const repo of AVAILABLE_REPOS) {
-        const fileList = await listGithubImageList(repo.user, repo.name, repo.subFolderList);
-        if (!fileList) {
-            continue;
-        }
-        const targetFile = _.find(fileList, (item) => fileNameRegExp.test(item.path));
-        if (targetFile) {
-            fileUrl = `https://raw.githubusercontent.com/${repo.user}/${repo.name}/master/${repo.subFolderList.join('/')}/${targetFile.path}`;
-            break;
-        }
+    const fileList = await listGithubImageList(githubImageOption);
+    if (!fileList) {
+        throw new Error(`Failed to list https://github.com/${githubRepo}`);;
     }
-    if (fileUrl === null) {
+    const targetFile = _.find(fileList, (item) => fileNameRegExp.test(item.path));
+    if (targetFile) {
+        fileUrl = `https://raw.githubusercontent.com/${githubRepo}/master/${subFolderList.join('/')}/${targetFile.path}`;
+    }
+    if (!fileUrl) {
         throw new Error(`Failed to get developer image for iOS ${finalVersion}`);
     }
     try {
         log.info(`Downloading developer image for ${finalVersion} to ${fullDownloadPath} from ${fileUrl}`);
         await net.downloadFile(fileUrl, fullDownloadPath);
     } catch (e) {
-        await unlink(fullDownloadPath);
+        await rimraf(fullDownloadPath);
         throw e;
     }
 }

--- a/lib/imagemounter/utils/list_developer_image.js
+++ b/lib/imagemounter/utils/list_developer_image.js
@@ -50,7 +50,7 @@ async function listGithubImageList(githubImageOption) {
     const fileList = [];
     let curUrl = initialUrl;
     /**
-     * @type {GithubTreeObject[]|undefined}
+     * @type {GithubTreeObject[] | undefined}
      */
     for (let i = 0; i <= subFolderList.length; i++) {
         const res = await axios.get(curUrl);

--- a/lib/imagemounter/utils/list_developer_image.js
+++ b/lib/imagemounter/utils/list_developer_image.js
@@ -32,6 +32,7 @@ const { exists, readdir, mkdir, rimraf } = fs;
  * The image and signature files should be compressed into a zip format, and the filename should match this regular expression:
  *  `${finalVersion}(\\(([\\w_|.()])+\\))?.zip`
  * @property {string} githubRepo This should be in format of `$(group or username)/${repository}`, which contains available images.
+ * @property {string} branch
  * @property {string[]} [subFolderList] subfolder list in level order
  */
 const DEFAULT_IMAGE_DIR_NAME = 'iOSDeviceSupport';
@@ -44,8 +45,8 @@ const DEVELOPER_IMAGE_SIGNATURE_FILE_NAME = 'DeveloperDiskImage.dmg.signature';
  * @returns {Promise<GithubTreeObject[] | undefined>} file list under target folder
  */
 async function listGithubImageList(githubImageOption) {
-    const { githubRepo, subFolderList = [] } = githubImageOption;
-    const initialUrl = `https://api.github.com/repos/${githubRepo}/git/trees/master`;
+    const { githubRepo, subFolderList = [], branch = 'master' } = githubImageOption;
+    const initialUrl = `https://api.github.com/repos/${githubRepo}/git/trees/${branch}`;
     const repoUrl = `https://github.com/${githubRepo}/`;
     const fileList = [];
     let curUrl = initialUrl;
@@ -152,7 +153,7 @@ async function findDeveloperImage(version, githubImageOption) {
  */
 async function searchAndDownloadDeveloperImageFromGithub(finalVersion, fullDownloadPath, githubImageOption) {
     const fileNameRegExp = new RegExp(`${_.escapeRegExp(finalVersion)}(\\(([\\w_|.()])+\\))?.zip`);
-    const { githubRepo, subFolderList = [] } = githubImageOption;
+    const { githubRepo, subFolderList = [], branch = 'master' } = githubImageOption;
     /** @type {string | undefined} */
     let fileUrl;
     const fileList = await listGithubImageList(githubImageOption);
@@ -162,7 +163,7 @@ async function searchAndDownloadDeveloperImageFromGithub(finalVersion, fullDownl
     const targetFile = _.find(fileList, (item) => fileNameRegExp.test(item.path));
     const subFolderPath = `${subFolderList.length > 0 ? '/' : ''}${subFolderList.join('/')}${subFolderList.length > 0 ? '/' : ''}`;
     if (targetFile) {
-        fileUrl = `https://raw.githubusercontent.com/${githubRepo}/master${subFolderPath}${targetFile.path}`;
+        fileUrl = `https://raw.githubusercontent.com/${githubRepo}/${branch}${subFolderPath}${targetFile.path}`;
     }
     if (!fileUrl) {
         throw new Error(`Failed to get developer image for iOS ${finalVersion}`);

--- a/lib/imagemounter/utils/list_developer_image.js
+++ b/lib/imagemounter/utils/list_developer_image.js
@@ -1,0 +1,182 @@
+import _ from 'lodash';
+import { zip, net } from '@appium/support';
+import { homedir } from 'os';
+import { join as joinPath } from 'path';
+import fetch from 'node-fetch';
+import { readdirSync, lstatSync, existsSync, mkdirSync, unlinkSync } from 'fs';
+import log from '../../logger';
+/**
+ * @typedef {Object} GithubTreeObject
+ * @property {string} path
+ * @property {string} mode
+ * @property {'blob' | 'tree'} type
+ * @property {string} sha
+ * @property {number} size
+ * @property {string} url
+ */
+
+/**
+ * @typedef {Object} GithubTreeResponse
+ * @property {string} sha
+ * @property {string} url
+ * @property {GithubTreeObject[]?} tree
+ * @property {boolean?} truncated
+ * @property {string?} node_id
+ * @property {number?} size
+ * @property {string?} content
+ * @property {string?} base64
+ */
+
+const AVAILABLE_REPOS = [
+    {
+        user: 'JinjunHan',
+        name: 'iOSDeviceSupport',
+        subFolderList: ['iOSDeviceSupport']
+    }, {
+        user: 'filsv',
+        name: 'iOSDeviceSupport',
+        subFolderList: []
+    }, {
+        user: 'iGhibli',
+        name: 'iOS-DeviceSupport',
+        subFolderList: ['DeviceSupport']
+    }
+];
+const HOME_DIR = homedir();
+const DEFAULT_IMAGE_DIR = joinPath(HOME_DIR, '.appium', 'iOSDeviceSupport');
+const DEVELOPER_IMAGE_FILE_NAME = 'DeveloperDiskImage.dmg';
+const DEVELOPER_IMAGE_SIGNATURE_FILE_NAME = 'DeveloperDiskImage.dmg.signature';
+
+/**
+ * Use list api to return the file list of folder.
+ * @param {string} user github user
+ * @param {string} name the name of repository
+ * @param subFolderList subfolder list in level order
+ * @returns {GithubTreeObject?} file list under target folder
+ */
+async function listGithubImageList(user, name, subFolderList = []) {
+    const initialUrl = `https://api.github.com/repos/${user}/${name}/git/trees/master`;
+    const repoUrl = `https://github.com/${user}/${name}/`;
+    const fileList = [];
+    let curUrl = initialUrl;
+    /**
+     * @type {GithubTreeObject[]?}
+     */
+    let ret = null;
+    for (let i = 0; i <= subFolderList.length; i++) {
+        /**
+         * @type {GithubTreeResponse}
+         */
+        const body = await fetch(curUrl).then((r) => r.json());
+        if (!body.tree) {
+            throw Error(`Failed on looking up ${fileList.join('/')} under ${repoUrl}: ${JSON.stringify(body)}`);
+        }
+        if (i === subFolderList.length) {
+            ret = body.tree;
+            break;
+        }
+        const entry = subFolderList[i];
+        const nextItem = _.find(body.tree, (item) => item.path === entry);
+        if (!nextItem) {
+            throw Error(`Unable to find ${entry} under ${fileList.join('/')} in under ${repoUrl}: ${JSON.stringify(body.tree)}`);
+        }
+        if (nextItem.type !== 'tree') {
+            throw Error(`${entry} under under ${fileList.join('/')} in under ${repoUrl} is expected to be a tree, got ${nextItem.type} instead.`);
+        }
+        fileList.push(entry);
+        curUrl = nextItem.url;
+    }
+    return ret;
+}
+
+/**
+ * Find `DeveloperDiskImage.dmg` recursively under folder and subfolder.
+ * @param {string} entry current folder
+ * @returns {string | undefined} parent folder of `DeveloperDiskImage.dmg` or `undefined` if no such file exists
+ */
+function findDeveloperImageFromDirectory(entry) {
+    const fileList = readdirSync(entry);
+    for (const subEntry of fileList) {
+        const fullPath = joinPath(entry, subEntry);
+        const statResult = lstatSync(fullPath);
+        if (subEntry === DEVELOPER_IMAGE_FILE_NAME && statResult.isFile()) {
+            return entry;
+        }
+        if (statResult.isDirectory()) {
+            const subFolderResult = findDeveloperImageFromDirectory(fullPath);
+            if (subFolderResult) {
+                return subFolderResult;
+            }
+        }
+    }
+    return undefined;
+}
+
+/**
+ * @typedef {Object} ImagePath
+ * @property {string} developerImage
+ * @property {string} developerImageSignature
+ */
+
+/**
+ * Find developer image for certain version. If developer image does not exists,
+ * this will try to find and download developer image, unzip to `~/.appium/iOSSupport/`
+ * @param {string} version full version of iOS device
+ * @returns {ImagePath}
+ * @throws If developer image is not found, or error while downloading or unzipping.
+ */
+async function findDeveloperImage(version) {
+    const finalVersion = version.split('.').splice(0, 2).join('.');
+    const fileName = `${finalVersion}.zip`;
+    const fullDownloadPath = joinPath(DEFAULT_IMAGE_DIR, fileName);
+    if (!existsSync(DEFAULT_IMAGE_DIR)) {
+        mkdirSync(DEFAULT_IMAGE_DIR, { recursive: true });
+    }
+    if (!existsSync(fullDownloadPath)) {
+        await searchAndDownloadDeveloperImageFromGithub(finalVersion, fullDownloadPath);
+    }
+    const decompressPath = joinPath(DEFAULT_IMAGE_DIR, finalVersion);
+    let developerImageParentFolder = null;
+    if (existsSync(decompressPath)) {
+        developerImageParentFolder = findDeveloperImageFromDirectory(decompressPath);
+    }
+    if (!developerImageParentFolder) {
+        await zip.extractAllTo(fullDownloadPath, decompressPath);
+        developerImageParentFolder = findDeveloperImageFromDirectory(decompressPath);
+    }
+    if (!developerImageParentFolder) {
+        throw Error(`Unable to find unzipped developer image in ${decompressPath}`);
+    }
+    return {
+        developerImage: joinPath(developerImageParentFolder, DEVELOPER_IMAGE_FILE_NAME),
+        developerImageSignature: joinPath(developerImageParentFolder, DEVELOPER_IMAGE_SIGNATURE_FILE_NAME)
+    };
+}
+
+async function searchAndDownloadDeveloperImageFromGithub(finalVersion, fullDownloadPath) {
+    const fileNameRegExp = new RegExp(`${finalVersion}(\\(([\\w_|.()])+\\))?.zip`);
+    let fileUrl = null;
+    for (const repo of AVAILABLE_REPOS) {
+        const fileList = await listGithubImageList(repo.user, repo.name, repo.subFolderList);
+        if (!fileList) {
+            continue;
+        }
+        const targetFile = _.find(fileList, (item) => fileNameRegExp.test(item.path));
+        if (targetFile != null) {
+            fileUrl = `https://raw.githubusercontent.com/${repo.user}/${repo.name}/master/${repo.subFolderList.join('/')}/${targetFile.path}`;
+            break;
+        }
+    }
+    if (fileUrl === null) {
+        throw Error(`Failed to get developer image for iOS ${finalVersion}`);
+    }
+    try {
+        log.info(`Downloading developer image for ${finalVersion} to ${fullDownloadPath} from ${fileUrl}`);
+        await net.downloadFile(fileUrl, fullDownloadPath);
+    } catch (e) {
+        unlinkSync(fullDownloadPath);
+        throw e;
+    }
+}
+
+export { findDeveloperImage };

--- a/lib/instrument/transformer/nskeyed.js
+++ b/lib/instrument/transformer/nskeyed.js
@@ -483,7 +483,7 @@ class Archive {
         return this.encodeDict(obj, archiveObj);
       }
     } else {
-      throw Error(`Unable to encode types: ${typeof obj}`);
+      throw new Error(`Unable to encode types: ${typeof obj}`);
     }
   }
 
@@ -553,7 +553,7 @@ function unarchive(inputBytes) {
  */
 function updateNSKeyedArchiveClass(name, subClass) {
   if (!_.isFunction(subClass.prototype?.decodeArchive) && !_.isFunction(subClass.prototype?.encodeArchive)) {
-    throw Error('subClass must have decodeArchive or encodeArchive methods');
+    throw new Error('subClass must have decodeArchive or encodeArchive methods');
   }
   if (!(name in UNARCHIVE_CLASS_MAP)) {
     UNARCHIVE_CLASS_MAP[name] = subClass;

--- a/lib/instrument/transformer/nskeyed.js
+++ b/lib/instrument/transformer/nskeyed.js
@@ -2,6 +2,7 @@ import plistlib from 'bplist-parser';
 import bplistCreate from 'bplist-creator';
 import { parse as uuidParse, stringify as uuidStringify } from 'uuid';
 import _ from 'lodash';
+import { format as stringFormat } from 'node:util';
 
 const NSKEYED_ARCHIVE_VERSION = 100_000;
 const NULL_UID = new plistlib.UID(0);
@@ -483,7 +484,7 @@ class Archive {
         return this.encodeDict(obj, archiveObj);
       }
     } else {
-      throw new Error(`Unable to encode types: ${typeof obj}`);
+      throw new Error(`Unable to encode types: ${stringFormat('%O', obj)}`);
     }
   }
 

--- a/lib/services.js
+++ b/lib/services.js
@@ -91,16 +91,16 @@ async function startHouseArrestService(udid, opts = {}) {
 async function startInstrumentService(udid, opts = {}) {
   const osVersion = opts.osVersion || await getOSVersion(udid, opts.socket);
   return new InstrumentService(parseInt(osVersion.split('.')[0], 10) < INSTRUMENT_HANDSHAKE_VERSION
-      ? await startService(udid, INSTRUMENT_SERVICE_NAME, opts.socket, true)
-      : await startService(udid, INSTRUMENT_SERVICE_NAME_VERSION_14, opts.socket)
+    ? await startService(udid, INSTRUMENT_SERVICE_NAME, opts.socket, true)
+    : await startService(udid, INSTRUMENT_SERVICE_NAME_VERSION_14, opts.socket)
   );
 }
 
 async function startTestmanagerdService(udid, opts = {}) {
   const osVersion = opts.osVersion || await getOSVersion(udid, opts.socket);
   return new TestmanagerdService(parseInt(osVersion.split('.')[0], 10) < TESTMANAGERD_HANDSHAKE_VERSION
-      ? await startService(udid, TESTMANAGERD_SERVICE_NAME, opts.socket, true)
-      : await startService(udid, TESTMANAGERD_SERVICE_NAME_VERSION_14, opts.socket)
+    ? await startService(udid, TESTMANAGERD_SERVICE_NAME, opts.socket, true)
+    : await startService(udid, TESTMANAGERD_SERVICE_NAME_VERSION_14, opts.socket)
   );
 }
 
@@ -127,7 +127,7 @@ async function startService(udid, serviceName, socket, handshakeOnly = false, tr
     if (!tryMountIfFailed || serviceName === MOBILE_IMAGE_MOUNTER_SERVICE_NAME) {
       throw e;
     }
-    if (e.message?.includes('InvalidService') && autoMountDeveloperImage(udid)) {
+    if (e.message?.includes('InvalidService') && await autoMountDeveloperImage(udid)) {
       return startService(udid, serviceName, socket, handshakeOnly, false);
     }
   } finally {
@@ -135,6 +135,11 @@ async function startService(udid, serviceName, socket, handshakeOnly = false, tr
   }
 }
 
+/**
+ * mount developer image based on device version and local storage.
+ * @param {string} udid
+ * @returns If mount success
+ */
 async function autoMountDeveloperImage(udid) {
   const osVersion = await getOSVersion(udid);
   let localImagePath;

--- a/lib/services.js
+++ b/lib/services.js
@@ -12,8 +12,7 @@ import { MCInstallProxyService, MC_INSTALL_SERVICE_NAME } from './mcinstall';
 import { ImageMounter, MOBILE_IMAGE_MOUNTER_SERVICE_NAME } from './imagemounter';
 import PlistService from './plist-service';
 import semver from 'semver';
-import { findDeveloperImage } from './imagemounter/utils/list_developer_image';
-import log from './logger';
+
 
 const CRASH_LOG_SERVICE_NAME = 'com.apple.crashreportcopymobile';
 const INSTRUMENT_HANDSHAKE_VERSION = 14;
@@ -110,11 +109,11 @@ async function startMCInstallService(udid, opts = {}) {
 }
 
 async function startImageMounterService(udid, opts = {}) {
-  const socket = await startService(udid, MOBILE_IMAGE_MOUNTER_SERVICE_NAME, opts.socket, false, false);
+  const socket = await startService(udid, MOBILE_IMAGE_MOUNTER_SERVICE_NAME, opts.socket, false);
   return new ImageMounter(new PlistService(socket));
 }
 
-async function startService(udid, serviceName, socket, handshakeOnly = false, tryMountIfFailed = true) {
+async function startService(udid, serviceName, socket, handshakeOnly = false) {
   const lockdown = await startLockdownSession(udid, socket);
   try {
     const service = await lockdown.startService(serviceName);
@@ -123,42 +122,9 @@ async function startService(udid, serviceName, socket, handshakeOnly = false, tr
     } else {
       return await connectPort(udid, service.Port, socket);
     }
-  } catch (e) {
-    if (!tryMountIfFailed || serviceName === MOBILE_IMAGE_MOUNTER_SERVICE_NAME) {
-      throw e;
-    }
-    if (e.message?.includes('InvalidService') && await autoMountDeveloperImage(udid)) {
-      return startService(udid, serviceName, socket, handshakeOnly, false);
-    }
   } finally {
     lockdown.close();
   }
-}
-
-/**
- * mount developer image based on device version and local storage.
- * @param {string} udid
- * @returns If mount success
- */
-async function autoMountDeveloperImage(udid) {
-  const osVersion = await getOSVersion(udid);
-  let localImagePath;
-  try {
-    localImagePath = await findDeveloperImage(osVersion);
-  } catch (e) {
-    log.error(`Failed on fetching image for ${udid} with iOS ${osVersion}`);
-    return false;
-  }
-  const imageMountService = await startImageMounterService(udid);
-  try {
-    await imageMountService.mount(localImagePath.developerImage, localImagePath.developerImageSignature);
-  } catch (e) {
-    log.error(`Failed to mount image for ${udid} with iOS ${osVersion} with ${JSON.stringify(localImagePath)}`);
-    return false;
-  } finally {
-    imageMountService.close();
-  }
-  return true;
 }
 
 export {

--- a/lib/services.js
+++ b/lib/services.js
@@ -6,27 +6,30 @@ import { InstallationProxyService, INSTALLATION_PROXY_SERVICE_NAME } from './ins
 import { AfcService, AFC_SERVICE_NAME } from './afc';
 import { NotificationProxyService, NOTIFICATION_PROXY_SERVICE_NAME } from './notification-proxy';
 import { HouseArrestService, HOUSE_ARREST_SERVICE_NAME } from './house-arrest';
-import { InstrumentService, INSTRUMENT_SERVICE_NAME_VERSION_14, INSTRUMENT_SERVICE_NAME} from './instrument';
+import { InstrumentService, INSTRUMENT_SERVICE_NAME_VERSION_14, INSTRUMENT_SERVICE_NAME } from './instrument';
 import { TestmanagerdService, TESTMANAGERD_SERVICE_NAME_VERSION_14, TESTMANAGERD_SERVICE_NAME } from './testmanagerd';
-import { MCInstallProxyService, MC_INSTALL_SERVICE_NAME} from './mcinstall';
+import { MCInstallProxyService, MC_INSTALL_SERVICE_NAME } from './mcinstall';
+import { ImageMounter, MOBILE_IMAGE_MOUNTER_SERVICE_NAME } from './imagemounter';
 import PlistService from './plist-service';
 import semver from 'semver';
+import { findDeveloperImage } from './imagemounter/utils/list_developer_image';
+import log from './logger';
 
 const CRASH_LOG_SERVICE_NAME = 'com.apple.crashreportcopymobile';
 const INSTRUMENT_HANDSHAKE_VERSION = 14;
 const TESTMANAGERD_HANDSHAKE_VERSION = 14;
 
-async function startSyslogService (udid, opts = {}) {
+async function startSyslogService(udid, opts = {}) {
   const socket = await startService(udid, SYSLOG_SERVICE_NAME, opts.socket);
   return new SyslogService(socket);
 }
 
-async function startSimulateLocationService (udid, opts = {}) {
+async function startSimulateLocationService(udid, opts = {}) {
   const socket = await startService(udid, SIMULATE_LOCATION_SERVICE_NAME, opts.socket);
   return new SimulateLocationService(socket);
 }
 
-async function startWebInspectorService (udid, opts = {}) {
+async function startWebInspectorService(udid, opts = {}) {
   const osVersion = opts.osVersion || await getOSVersion(udid, opts.socket);
   const isSimulator = !!opts.isSimulator;
   const verbose = !!opts.verbose;
@@ -60,55 +63,58 @@ async function startWebInspectorService (udid, opts = {}) {
   });
 }
 
-async function startInstallationProxyService (udid, opts = {}) {
+async function startInstallationProxyService(udid, opts = {}) {
   const socket = await startService(udid, INSTALLATION_PROXY_SERVICE_NAME, opts.socket);
   return new InstallationProxyService(new PlistService(socket));
 }
 
-async function startAfcService (udid, opts = {}) {
+async function startAfcService(udid, opts = {}) {
   const socket = await startService(udid, AFC_SERVICE_NAME, opts.socket);
   return new AfcService(socket);
 }
 
-async function startCrashLogService (udid, opts = {}) {
+async function startCrashLogService(udid, opts = {}) {
   const socket = await startService(udid, CRASH_LOG_SERVICE_NAME, opts.socket);
   return new AfcService(socket);
 }
 
-async function startNotificationProxyService (udid, opts = {}) {
+async function startNotificationProxyService(udid, opts = {}) {
   const socket = await startService(udid, NOTIFICATION_PROXY_SERVICE_NAME, opts.socket);
   return new NotificationProxyService(socket);
 }
 
-async function startHouseArrestService (udid, opts = {}) {
+async function startHouseArrestService(udid, opts = {}) {
   const socket = await startService(udid, HOUSE_ARREST_SERVICE_NAME, opts.socket);
   return new HouseArrestService(socket);
 }
 
-async function startInstrumentService (udid, opts = {}) {
+async function startInstrumentService(udid, opts = {}) {
   const osVersion = opts.osVersion || await getOSVersion(udid, opts.socket);
-  return new InstrumentService(
-  parseInt(osVersion.split('.')[0], 10) < INSTRUMENT_HANDSHAKE_VERSION
-    ? await startService(udid, INSTRUMENT_SERVICE_NAME, opts.socket, true)
-    : await startService(udid, INSTRUMENT_SERVICE_NAME_VERSION_14, opts.socket)
+  return new InstrumentService(parseInt(osVersion.split('.')[0], 10) < INSTRUMENT_HANDSHAKE_VERSION
+      ? await startService(udid, INSTRUMENT_SERVICE_NAME, opts.socket, true)
+      : await startService(udid, INSTRUMENT_SERVICE_NAME_VERSION_14, opts.socket)
   );
 }
 
-async function startTestmanagerdService (udid, opts = {}) {
+async function startTestmanagerdService(udid, opts = {}) {
   const osVersion = opts.osVersion || await getOSVersion(udid, opts.socket);
-  return new TestmanagerdService(
-    parseInt(osVersion.split('.')[0], 10) < TESTMANAGERD_HANDSHAKE_VERSION
+  return new TestmanagerdService(parseInt(osVersion.split('.')[0], 10) < TESTMANAGERD_HANDSHAKE_VERSION
       ? await startService(udid, TESTMANAGERD_SERVICE_NAME, opts.socket, true)
       : await startService(udid, TESTMANAGERD_SERVICE_NAME_VERSION_14, opts.socket)
   );
 }
 
-async function startMCInstallService (udid, opts = {}) {
+async function startMCInstallService(udid, opts = {}) {
   const socket = await startService(udid, MC_INSTALL_SERVICE_NAME, opts.socket);
   return new MCInstallProxyService(new PlistService(socket));
 }
 
-async function startService (udid, serviceName, socket, handshakeOnly = false) {
+async function startImageMounterService(udid, opts = {}) {
+  const socket = await startService(udid, MOBILE_IMAGE_MOUNTER_SERVICE_NAME, opts.socket, false, false);
+  return new ImageMounter(new PlistService(socket));
+}
+
+async function startService(udid, serviceName, socket, handshakeOnly = false, tryMountIfFailed = true) {
   const lockdown = await startLockdownSession(udid, socket);
   try {
     const service = await lockdown.startService(serviceName);
@@ -117,9 +123,37 @@ async function startService (udid, serviceName, socket, handshakeOnly = false) {
     } else {
       return await connectPort(udid, service.Port, socket);
     }
+  } catch (e) {
+    if (!tryMountIfFailed || serviceName === MOBILE_IMAGE_MOUNTER_SERVICE_NAME) {
+      throw e;
+    }
+    if (e.message?.includes('InvalidService') && autoMountDeveloperImage(udid)) {
+      return startService(udid, serviceName, socket, handshakeOnly, false);
+    }
   } finally {
     lockdown.close();
   }
+}
+
+async function autoMountDeveloperImage(udid) {
+  const osVersion = await getOSVersion(udid);
+  let localImagePath;
+  try {
+    localImagePath = await findDeveloperImage(osVersion);
+  } catch (e) {
+    log.error(`Failed on fetching image for ${udid} with iOS ${osVersion}`);
+    return false;
+  }
+  const imageMountService = await startImageMounterService(udid);
+  try {
+    await imageMountService.mount(localImagePath.developerImage, localImagePath.developerImageSignature);
+  } catch (e) {
+    log.error(`Failed to mount image for ${udid} with iOS ${osVersion} with ${JSON.stringify(localImagePath)}`);
+    return false;
+  } finally {
+    imageMountService.close();
+  }
+  return true;
 }
 
 export {
@@ -127,5 +161,5 @@ export {
   startInstallationProxyService, startSimulateLocationService,
   startAfcService, startCrashLogService, startNotificationProxyService,
   startHouseArrestService, startInstrumentService, startTestmanagerdService,
-  startMCInstallService
+  startMCInstallService, startImageMounterService
 };

--- a/lib/utilities.js
+++ b/lib/utilities.js
@@ -263,8 +263,6 @@ async function mountDeveloperImage(udid, opts) {
   const imageMountService = await startImageMounterService(udid);
   try {
     await imageMountService.mount(developerImage, developerImageSignature);
-  } catch (e) {
-    log.error(`Failed to mount image for ${udid} with iOS ${osVersion} with ${JSON.stringify({ developerImage, developerImageSignature })}`);
   } finally {
     imageMountService.close();
   }

--- a/lib/utilities.js
+++ b/lib/utilities.js
@@ -2,6 +2,8 @@ import Usbmux, { getDefaultSocket } from './usbmux';
 import { upgradeToSSL, enableSSLHandshakeOnly } from './ssl-helper';
 import _ from 'lodash';
 import log from './logger';
+import { findDeveloperImage } from './imagemounter/utils/list_developer_image';
+import { startImageMounterService } from './services';
 
 // https://github.com/samdmarshall/iOS-Internals/blob/master/lockbot/lockbot/lockdown_keys.h
 const LOCKDOWN_REQUEST = {
@@ -20,7 +22,7 @@ const LOCKDOWN_REQUEST = {
  * @returns {Array.<string>} The list of device serial numbers (udid) or
  * an empty list if no devices are connected
  */
-async function getConnectedDevices (socket = null) {
+async function getConnectedDevices(socket = null) {
   let usbmux;
   try {
     usbmux = new Usbmux(socket || await getDefaultSocket());
@@ -44,7 +46,7 @@ async function getConnectedDevices (socket = null) {
  * @param {import('net').Socket?} socket the socket of usbmuxd. It will default to /var/run/usbmuxd if it is not passed
  * @returns {string}
  */
-async function getOSVersion (udid, socket = null) {
+async function getOSVersion(udid, socket = null) {
   const usbmux = new Usbmux(socket || await getDefaultSocket());
   try {
     // lockdown doesn't need to be closed since it uses the same socket usbmux uses
@@ -62,7 +64,7 @@ async function getOSVersion (udid, socket = null) {
  * @param {import('net').Socket?} socket the socket of usbmuxd. It will default to /var/run/usbmuxd if it is not passed
  * @returns {string}
  */
-async function getDeviceName (udid, socket = null) {
+async function getDeviceName(udid, socket = null) {
   const usbmux = new Usbmux(socket || await getDefaultSocket());
   try {
     // lockdown doesn't need to be closed since it uses the same socket usbmux uses
@@ -112,7 +114,7 @@ async function getDeviceName (udid, socket = null) {
  *   "WiFiAddress"=>"00:00:00:00:00:00"
  * }
  */
-async function getDeviceInfo (udid, socket = null) {
+async function getDeviceInfo(udid, socket = null) {
   const usbmux = new Usbmux(socket || await getDefaultSocket());
   try {
     const lockdown = await usbmux.connectLockdown(udid);
@@ -138,7 +140,7 @@ async function getDeviceInfo (udid, socket = null) {
  * @param {import('net').Socket?} socket the socket of usbmuxd. It will default to /var/run/usbmuxd if it is not passed
  * @returns {DeviceTime}
  */
-async function getDeviceTime (udid, socket = null) {
+async function getDeviceTime(udid, socket = null) {
   const lockdown = await startLockdownSession(udid, socket);
   try {
     return {
@@ -159,7 +161,7 @@ async function getDeviceTime (udid, socket = null) {
  * @param {import('net').Socket?} socket the socket of usbmuxd. It will default to /var/run/usbmuxd if it is not passed
  * @returns {Lockdown}
  */
-async function startLockdownSession (udid, socket = null) {
+async function startLockdownSession(udid, socket = null) {
   const usbmux = new Usbmux(socket || await getDefaultSocket());
   try {
     const pairRecord = await usbmux.readPairRecord(udid);
@@ -186,7 +188,7 @@ async function startLockdownSession (udid, socket = null) {
  * @param {boolean} handshakeOnly only handshake and return the initial socket
  * @returns {tls.TLSSocket|Object} The socket or the object returned in the callback if the callback function exists
  */
-async function connectPortSSL (udid, port, socket = null, handshakeOnly = false) {
+async function connectPortSSL(udid, port, socket = null, handshakeOnly = false) {
   const usbmux = new Usbmux(socket || await getDefaultSocket());
   try {
     const device = await usbmux.findDevice(udid);
@@ -215,7 +217,7 @@ async function connectPortSSL (udid, port, socket = null, handshakeOnly = false)
  * @param {import('net').Socket?} socket the socket of usbmuxd. It will default to /var/run/usbmuxd if it is not passed
  * @returns {net.Socket|Object} The socket or the object returned in the callback if the callback function exists
  */
-async function connectPort (udid, port, socket = null) {
+async function connectPort(udid, port, socket = null) {
   const usbmux = new Usbmux(socket || await getDefaultSocket());
   try {
     const device = await usbmux.findDevice(udid);
@@ -229,7 +231,51 @@ async function connectPort (udid, port, socket = null) {
   }
 }
 
+/**
+ * @typedef {
+ * import('./imagemounter/utils/list_developer_image').ImageFromGithubRepo
+ * | import('./imagemounter/utils/list_developer_image').ImagePath
+ * } MountOpts Local path or github repo
+ */
+
+/**
+ * mount developer image based on device version and local storage.
+ * @param {string} udid
+ * @param {MountOpts} opts local image and signature files or github repo option.
+ * @throws If opts error or mount faile
+ */
+async function mountDeveloperImage(udid, opts) {
+  const osVersion = await getOSVersion(udid);
+  /**
+   * @type {import('./utils/list_developer_image.ImagePath')}
+   */
+  let { developerImage, developerImageSignature } = opts;
+  // Not a local path in `ImagePath` format, try to use github repo
+  if (!developerImage || !developerImageSignature) {
+    // Not containing any github setting, invalid opts
+    if (!opts.repo) {
+      throw new TypeError(`Mount option should contains local path or github repo, got ${JSON.stringify(opts)} instead`);
+    }
+    try {
+      ({ developerImage, developerImageSignature } = await findDeveloperImage(osVersion, opts));
+    } catch (e) {
+      log.error(`Failed on fetching image for ${udid} with iOS ${osVersion}`);
+      throw e;
+    }
+  }
+  const imageMountService = await startImageMounterService(udid);
+  try {
+    await imageMountService.mount(developerImage, developerImageSignature);
+  } catch (e) {
+    log.error(`Failed to mount image for ${udid} with iOS ${osVersion} with ${JSON.stringify({ developerImage, developerImageSignature })}`);
+  } finally {
+    imageMountService.close();
+  }
+}
+
+
 export {
   getConnectedDevices, getOSVersion, getDeviceName, getDeviceTime,
-  startLockdownSession, connectPort, connectPortSSL, getDeviceInfo
+  startLockdownSession, connectPort, connectPortSSL, getDeviceInfo,
+  mountDeveloperImage
 };

--- a/lib/utilities.js
+++ b/lib/utilities.js
@@ -246,9 +246,6 @@ async function connectPort(udid, port, socket = null) {
  */
 async function mountDeveloperImage(udid, opts) {
   const osVersion = await getOSVersion(udid);
-  /**
-   * @type {import('./utils/list_developer_image.ImagePath')}
-   */
   let { developerImage, developerImageSignature } = opts;
   // Not a local path in `ImagePath` format, try to use github repo
   if (!developerImage || !developerImageSignature) {

--- a/lib/utilities.js
+++ b/lib/utilities.js
@@ -3,7 +3,6 @@ import { upgradeToSSL, enableSSLHandshakeOnly } from './ssl-helper';
 import _ from 'lodash';
 import log from './logger';
 import { findDeveloperImage } from './imagemounter/utils/list_developer_image';
-import { startImageMounterService } from './services';
 
 // https://github.com/samdmarshall/iOS-Internals/blob/master/lockbot/lockbot/lockdown_keys.h
 const LOCKDOWN_REQUEST = {
@@ -232,45 +231,30 @@ async function connectPort(udid, port, socket = null) {
 }
 
 /**
- * @typedef {
- * import('./imagemounter/utils/list_developer_image').ImageFromGithubRepo
- * | import('./imagemounter/utils/list_developer_image').ImagePath
- * } MountOpts Local path or github repo
- */
-
-/**
- * mount developer image based on device version and local storage.
+ * Search developer image for device based on given repo. If certain file was found, this would automatic download,
+ * unzip and return the path of developer image and signature file.
+ *
+ * Developer images and signature files should be put into a zip file that matches this regular expression:
+ * `\d+\.\d+(\(([\w_|.()])+\))?.zip`. The image file should be named to `DeveloperDiskImage.dmg`,
+ *  and the signature file should be named to `DeveloperDiskImage.dmg.signature`.
+ * Both files should be placed into same folder.
  * @param {string} udid
- * @param {MountOpts} opts local image and signature files or github repo option.
- * @throws If opts error or mount faile
+ * @param {import('./imagemounter/utils/list_developer_image').ImageFromGithubRepo} opts
+ * github repo option, `githubRepo` .
+ * @returns {Promise<import('./imagemounter/utils/list_developer_image').ImagePath>}
+ * @throws If opts error or failed on searching image
  */
-async function mountDeveloperImage(udid, opts) {
+async function fetchImageFromGithubRepo(udid, opts) {
   const osVersion = await getOSVersion(udid);
-  let { developerImage, developerImageSignature } = opts;
-  // Not a local path in `ImagePath` format, try to use github repo
-  if (!developerImage || !developerImageSignature) {
-    // Not containing any github setting, invalid opts
-    if (!opts.repo) {
-      throw new TypeError(`Mount option should contains local path or github repo, got ${JSON.stringify(opts)} instead`);
-    }
-    try {
-      ({ developerImage, developerImageSignature } = await findDeveloperImage(osVersion, opts));
-    } catch (e) {
-      log.error(`Failed on fetching image for ${udid} with iOS ${osVersion}`);
-      throw e;
-    }
+  if (!opts.githubRepo) {
+    throw new TypeError(`Mount option should contains local path or github repo, got ${JSON.stringify(opts)} instead`);
   }
-  const imageMountService = await startImageMounterService(udid);
-  try {
-    await imageMountService.mount(developerImage, developerImageSignature);
-  } finally {
-    imageMountService.close();
-  }
+  return await findDeveloperImage(osVersion, opts);
 }
 
 
 export {
   getConnectedDevices, getOSVersion, getDeviceName, getDeviceTime,
   startLockdownSession, connectPort, connectPortSSL, getDeviceInfo,
-  mountDeveloperImage
+  fetchImageFromGithubRepo
 };

--- a/lib/xctest.js
+++ b/lib/xctest.js
@@ -127,7 +127,7 @@ class Xctest {
             appPath, this.xctestBundleId, appEnv, appArgs, appOptions);
         const pid = launchResult.selector;
         if (typeof pid !== 'number') {
-            throw Error(`Failed on launching ${this.xctestBundleId}: ${launchResult}`);
+            throw new Error(`Failed on launching ${this.xctestBundleId}: ${launchResult}`);
         }
         log.info(`Pid of launched ${this.xctestBundleId}: ${pid}`);
         const msg = new DTXMessageAuxBuffer();

--- a/test/imagemounter/list-developer-image-specs.js
+++ b/test/imagemounter/list-developer-image-specs.js
@@ -8,12 +8,13 @@ describe('findDeveloperImage', function () {
     it('should download and return the correct developer image for a given version', async function () {
         const result = await findDeveloperImage('14.7.1', {
             githubRepo: 'appium/appium-ios-device',
-            subFolderList: ['test', 'imagemounter']
+            subFolderList: ['test', 'imagemounter'],
+            branch: 'imagemounter'
         });
         result.developerImage.endsWith('/DeveloperDiskImage.dmg').should.be.true;
         result.developerImageSignature.endsWith('/DeveloperDiskImage.dmg.signature').should.be.true;
-        fs.exists(result.developerImage).should.eventually.be.true;
-        fs.exists(result.developerImageSignature).should.eventually.be.true;
+        (await fs.exists(result.developerImage)).should.be.true;
+        (await fs.exists(result.developerImageSignature)).should.be.true;
     });
 
     it('should throw an error if the developer image cannot be found', function () {

--- a/test/imagemounter/list-developer-image-specs.js
+++ b/test/imagemounter/list-developer-image-specs.js
@@ -1,0 +1,22 @@
+import chai from 'chai';
+import { findDeveloperImage } from '../../lib/imagemounter/utils/list_developer_image';
+import { fs } from '@appium/support';
+chai.should();
+describe('findDeveloperImage', function() {
+    it('should download and return the correct developer image for a given version', async function() {
+        const result = await findDeveloperImage('14.7.1', { githubRepo: 'JinjunHan/iOSDeviceSupport', subFolderList: ['iOSDeviceSupport'] });
+        result.developerImage.should.endWith('/DeveloperDiskImage.dmg');
+        result.developerImageSignature.should.endWith('/DeveloperDiskImage.dmg.signature');
+        (await fs.exists(result.developerImage)).should.be.true;
+        (await fs.exists(result.developerImageSignature)).should.be.true;
+    });
+
+    it('should throw an error if the developer image cannot be found', async function() {
+        try {
+            await findDeveloperImage('99.99.99', { githubRepo: 'JinjunHan/iOSDeviceSupport', subFolderList: ['iOSDeviceSupport'] });
+            chai.assert.fail('Expected an error to be thrown');
+        } catch (err) {
+            err.message.should.equal('Failed to get developer image for iOS 99.99');
+        }
+    });
+});

--- a/test/imagemounter/list-developer-image-specs.js
+++ b/test/imagemounter/list-developer-image-specs.js
@@ -1,22 +1,25 @@
 import chai from 'chai';
+import chaiAsPromised from 'chai-as-promised';
 import { findDeveloperImage } from '../../lib/imagemounter/utils/list_developer_image';
 import { fs } from '@appium/support';
 chai.should();
-describe('findDeveloperImage', function() {
-    it('should download and return the correct developer image for a given version', async function() {
-        const result = await findDeveloperImage('14.7.1', { githubRepo: 'JinjunHan/iOSDeviceSupport', subFolderList: ['iOSDeviceSupport'] });
+chai.use(chaiAsPromised);
+describe('findDeveloperImage', function () {
+    it('should download and return the correct developer image for a given version', async function () {
+        const result = await findDeveloperImage('14.7.1', {
+            githubRepo: 'appium/appium-ios-device',
+            subFolderList: ['test', 'imagemounter']
+        });
         result.developerImage.endsWith('/DeveloperDiskImage.dmg').should.be.true;
         result.developerImageSignature.endsWith('/DeveloperDiskImage.dmg.signature').should.be.true;
-        (await fs.exists(result.developerImage)).should.be.true;
-        (await fs.exists(result.developerImageSignature)).should.be.true;
+        fs.exists(result.developerImage).should.eventually.be.true;
+        fs.exists(result.developerImageSignature).should.eventually.be.true;
     });
 
-    it('should throw an error if the developer image cannot be found', async function() {
-        try {
-            await findDeveloperImage('99.99.99', { githubRepo: 'JinjunHan/iOSDeviceSupport', subFolderList: ['iOSDeviceSupport'] });
-            chai.assert.fail('Expected an error to be thrown');
-        } catch (err) {
-            err.message.should.equal('Failed to get developer image for iOS 99.99');
-        }
+    it('should throw an error if the developer image cannot be found', function () {
+        findDeveloperImage('99.99.99', {
+            githubRepo: 'appium/appium-ios-device',
+            subFolderList: ['test', 'imagemounter']
+        }).should.be.rejectedWith('Failed to get developer image for iOS 99.99');
     });
 });

--- a/test/imagemounter/list-developer-image-specs.js
+++ b/test/imagemounter/list-developer-image-specs.js
@@ -5,8 +5,8 @@ chai.should();
 describe('findDeveloperImage', function() {
     it('should download and return the correct developer image for a given version', async function() {
         const result = await findDeveloperImage('14.7.1', { githubRepo: 'JinjunHan/iOSDeviceSupport', subFolderList: ['iOSDeviceSupport'] });
-        result.developerImage.should.endWith('/DeveloperDiskImage.dmg');
-        result.developerImageSignature.should.endWith('/DeveloperDiskImage.dmg.signature');
+        result.developerImage.endsWith('/DeveloperDiskImage.dmg').should.be.true;
+        result.developerImageSignature.endsWith('/DeveloperDiskImage.dmg.signature').should.be.true;
         (await fs.exists(result.developerImage)).should.be.true;
         (await fs.exists(result.developerImageSignature)).should.be.true;
     });


### PR DESCRIPTION
This is for solving [#18450](https://github.com/appium/appium/issues/18450) which was caused by missing developer image on lower version of Xcode or other OS.

I add a new service and operates auto mount procedure while getting 'InvalidService' error on starting service.
Does it make sense if I move autoMountDeveloperImage to utilities and export as a function?