### PR TITLE
chore: use latest lts for the publishment

### DIFF
--- a/.github/workflows/publish.js.yml
+++ b/.github/workflows/publish.js.yml
@@ -9,11 +9,12 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - name: Use Node.js 18.x
-      uses: actions/setup-node@v1
+    - uses: actions/checkout@v3
+    - name: Use Node.js LTS
+      uses: actions/setup-node@v3
       with:
-        node-version: 18.x
+        node-version: lts/*
+        check-latest: true
     - run: npm install --no-package-lock
       name: Install dev dependencies
     - run: npm run build


### PR DESCRIPTION
The latest publishment failed as nodejs 18 compatibility issue
https://github.com/appium/appium-ios-device/actions/runs/7547941800/job/20548972866