### PR TITLE
fix: Avoid throwing of runtime exception if DTXMessage cannot be decoded

### DIFF
--- a/lib/instrument/transformer/dtx-decode.js
+++ b/lib/instrument/transformer/dtx-decode.js
@@ -1,6 +1,9 @@
 import Stream from 'stream';
-import { DTX_MESSAGE_HEADER_LENGTH, DTX_MESSAGE_HEADER_MAGIC, DTX_MESSAGE_HEADER_MAGIC_LEN,
-         DTXMessageHeader, DTXMessage} from '../headers';
+import {
+  DTX_MESSAGE_HEADER_LENGTH, DTX_MESSAGE_HEADER_MAGIC, DTX_MESSAGE_HEADER_MAGIC_LEN,
+  DTXMessageHeader, DTXMessage,
+} from '../headers';
+import log from '../../logger';
 
 class DTXDecoder extends Stream.Transform {
 
@@ -49,7 +52,13 @@ class DTXDecoder extends Stream.Transform {
         data = this._dtxManager[this.header.channel];
         delete this._dtxManager[this.header.channel];
         if (data) {
-          this.push(DTXMessage.parse(data.headerBuffer, data.payloadBuffer));
+          try {
+            const dtxMessage = DTXMessage.parse(data.headerBuffer, data.payloadBuffer);
+            this.push(dtxMessage);
+          } catch (e) {
+            log.debug(e.stack);
+            log.error(`Skipped decoding of an unparseable DTXMessage: ${e.message}`);
+          }
         }
       }
     }

--- a/lib/instrument/transformer/nskeyed.js
+++ b/lib/instrument/transformer/nskeyed.js
@@ -3,6 +3,7 @@ import bplistCreate from 'bplist-creator';
 import { parse as uuidParse, stringify as uuidStringify } from 'uuid';
 import _ from 'lodash';
 import { format as stringFormat } from 'node:util';
+import log from '../../logger';
 
 const NSKEYED_ARCHIVE_VERSION = 100_000;
 // @ts-ignore UID is not exposed to typedefs
@@ -371,16 +372,22 @@ class Unarchive {
 
   unpackArchiveHeader() {
     const plist = plistlib.parseBuffer(this.input)[0];
+    const createPlistIssue = (/** @type {string} */ message) => {
+      try {
+        log.debug(`Source plist: ${_.truncate(JSON.stringify(plist), {length: 250})}`);
+      } catch (ign) {}
+      return new Error(message);
+    };
     if (plist.$archiver !== NSKEYEDARCHIVER) {
-      throw new Error(`unsupported encoder: ${plist.$archiver}`);
+      throw createPlistIssue(`unsupported encoder: ${plist.$archiver}`);
     }
     if (plist.$version !== NSKEYED_ARCHIVE_VERSION) {
-      throw new Error(`expected ${NSKEYED_ARCHIVE_VERSION}, got ${plist.$version}`);
+      throw createPlistIssue(`expected ${NSKEYED_ARCHIVE_VERSION}, got ${plist.$version}`);
     }
     const top = plist.$top;
     const topUID = top.root;
     if (!topUID) {
-      throw new Error(`top object did not have a UID! dump: ${JSON.stringify(top)}`);
+      throw createPlistIssue(`top object did not have a UID! dump: ${JSON.stringify(top)}`);
     }
     this.topUID = topUID;
     this.objects = plist.$objects;


### PR DESCRIPTION
This does not fix the original issue (e.g. fixes DTX message parsing), but at least the node process itself does not die due to an unhandled exception.