### PR TITLE
fix: set __ActivateSuspended to not block xctest run by popup

### DIFF
--- a/lib/xctest.js
+++ b/lib/xctest.js
@@ -127,6 +127,7 @@ class Xctest {
         const appOptions = { StartSuspendedKey: false };
         if (majorVersion >= MAJOR_IOS_VERSION_12) {
             appOptions.ActivateSuspended = true;
+            appOptions.__ActivateSuspended = true;
         }
         const launchResult = await this._instrumentService.callChannel(PROCESS_CONTROL,
             'launchSuspendedProcessWithDevicePath:bundleIdentifier:environment:arguments:options:',


### PR DESCRIPTION
This usage itself improves Appium's launching WDA method for ios 16 and lower since Appium uses `xcrun devicectl device process launch` for ios 17+. I have locally tested at least this didn't break anything.
(Inspired by https://github.com/danielpaulus/go-ios/pull/510)



https://github.com/appium/appium/issues/20270 for iOS 16 and lower should be improved. For iOS 17+, we need 3rd party such as go-ios. It looks like `xcrun devicectl device process launch` doesn't enable this.

Maybe... we also could add trobleshooting guid about:

```
3|appium bibit 3  | [IOSDeviceLog] Jun 24 10:04:11 iPhone-2 WebDriverAgentRunner-Runner(XCUIAutomation)[24467] <Error>: Failed to initialize for UI testing: Error Domain=com.apple.dt.xctest.ui-testing.error Code=10300 "Failed to background test runner within 30.0s." UserInfo={screenshot-data={length = 7507, bytes = 0x00000024 66747970 68656963 00000000 ... 02a60000 03000724 }, NSLocalizedDescription=Failed to background test runner within 30.0s.}
```

(from https://github.com/appium/appium/issues/20270#issuecomment-2185598908 ) to use this/go-ios later