### PR TITLE
fix: get usbmuxd socket address from USBMUXD_SOCKET_ADDRESS environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,10 @@ async function checkAndMountDeveloperImage(udid) {
 }
 ```
 
+### Environment
+
+* If exists, `USBMUXD_SOCKET_ADDRESS` is used to get usbmuxd socket address. Mostly useful in cases where the `usbmuxd` is run by a non-root user.
+
 ## Test
 
 ``` shell

--- a/lib/usbmux/index.js
+++ b/lib/usbmux/index.js
@@ -61,13 +61,25 @@ function swap16 (val) {
  * @throws {B.TimeoutError} if connection timeout happened
  * @returns {Promise<NodeJS.Socket>} Connected socket instance
  */
-async function getDefaultSocket (opts = {}) {
-  const {
+async function getDefaultSocket(opts = {}) {
+  let {
     socketPath = DEFAULT_USBMUXD_SOCKET,
     socketPort = DEFAULT_USBMUXD_PORT,
     socketHost = DEFAULT_USBMUXD_HOST,
     timeout = 5000,
   } = opts;
+
+  if (process.env.USBMUXD_SOCKET_ADDRESS) {
+    // "unix:" or "UNIX:" prefix is optional for unix socket paths.
+    const usbmuxdSocketAddress = process.env.USBMUXD_SOCKET_ADDRESS.replace(/^(unix|UNIX):/i, '');
+    let ipPortPair = usbmuxdSocketAddress.split(':');
+    if (ipPortPair.length === 2) {
+      socketHost = ipPortPair[0];
+      socketPort = parseInt(ipPortPair[1], 10);
+    } else {
+      socketPath = usbmuxdSocketAddress;
+    }
+  }
 
   let socket;
   if (await fs.exists(socketPath ?? '')) {

--- a/lib/usbmux/index.js
+++ b/lib/usbmux/index.js
@@ -11,6 +11,7 @@ import PlistService from '../plist-service';
 import { Lockdown, LOCKDOWN_PORT } from '../lockdown';
 import { BaseServiceSocket } from '../base-service';
 import { MB } from '../constants';
+import log from '../logger';
 
 
 const MAX_FRAME_SIZE = 1 * MB;
@@ -62,24 +63,27 @@ function swap16 (val) {
  * @returns {Promise<NodeJS.Socket>} Connected socket instance
  */
 async function getDefaultSocket(opts = {}) {
-  let {
-    socketPath = DEFAULT_USBMUXD_SOCKET,
-    socketPort = DEFAULT_USBMUXD_PORT,
-    socketHost = DEFAULT_USBMUXD_HOST,
-    timeout = 5000,
-  } = opts;
+  const defaults = {
+    socketPath: DEFAULT_USBMUXD_SOCKET,
+    socketPort: DEFAULT_USBMUXD_PORT,
+    socketHost: DEFAULT_USBMUXD_HOST,
+    timeout: 5000
+  };
 
-  if (process.env.USBMUXD_SOCKET_ADDRESS) {
+  if (process.env.USBMUXD_SOCKET_ADDRESS && !opts.socketPath && !opts.socketPort && !opts.socketHost) {
+    log.debug(`Using USBMUXD_SOCKET_ADDRESS environment variable as default socket: ${process.env.USBMUXD_SOCKET_ADDRESS}`);
     // "unix:" or "UNIX:" prefix is optional for unix socket paths.
-    const usbmuxdSocketAddress = process.env.USBMUXD_SOCKET_ADDRESS.replace(/^(unix|UNIX):/i, '');
-    let ipPortPair = usbmuxdSocketAddress.split(':');
-    if (ipPortPair.length === 2) {
-      socketHost = ipPortPair[0];
-      socketPort = parseInt(ipPortPair[1], 10);
+    const usbmuxdSocketAddress = process.env.USBMUXD_SOCKET_ADDRESS.replace(/^(unix):/i, '');
+    const [ip, port] = usbmuxdSocketAddress.split(':');
+    if (ip && port) {
+      defaults.socketHost = ip;
+      defaults.socketPort = parseInt(port, 10);
     } else {
-      socketPath = usbmuxdSocketAddress;
+      defaults.socketPath = usbmuxdSocketAddress;
     }
   }
+
+  const { socketPath, socketPort, socketHost, timeout } = { ...defaults, ...opts };
 
   let socket;
   if (await fs.exists(socketPath ?? '')) {


### PR DESCRIPTION
When `usbmuxd` is run without root user, it listens on a different path. `usbmuxd` itself [uses](https://github.com/libimobiledevice/libusbmuxd?tab=readme-ov-file#environment) this env var if it's given.

Tested manually with a real iPhone.