### PR TITLE
fix: Loop in base-service.js

### DIFF
--- a/lib/base-service.js
+++ b/lib/base-service.js
@@ -7,7 +7,7 @@ class BaseServiceSocket {
   }
 
   _assignClientFailureHandlers(...sourceStreams) {
-    for (const evt in ['close', 'end']) {
+    for (const evt of ['close', 'end']) {
       this._socketClient.once(evt,
         () => sourceStreams.map((s) => s.unpipe(this._socketClient)));
     }

--- a/lib/usbmux/transformer/usbmux-encoder.js
+++ b/lib/usbmux/transformer/usbmux-encoder.js
@@ -16,7 +16,8 @@ class UsbmuxEncoder extends Stream.Transform {
   }
 
   _encode (data) {
-    const payloadBuffer = Buffer.from(plist.createPlist(data.payload, false));
+    const plistData = plist.createPlist(data.payload, false);
+    const payloadBuffer = Buffer.isBuffer(plistData) ? plistData : Buffer.from(plistData);
 
     const header = {
       length: HEADER_LENGTH + payloadBuffer.length,

--- a/test/usbmux/usbmux-specs.js
+++ b/test/usbmux/usbmux-specs.js
@@ -12,13 +12,25 @@ describe('usbmux', function () {
     chai.should();
   });
 
-  afterEach(function () {
-    try {
-      usbmux.close();
-    } catch {}
-    try {
-      server.close();
-    } catch {}
+  afterEach(async function () {
+    if (usbmux) {
+      try {
+        usbmux.close();
+      } catch {}
+      usbmux = null;
+    }
+
+    // Add a small delay to avoid connection reset errors
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
+    if (server) {
+      try {
+        server.close();
+      } catch {}
+      server = null;
+    }
+
+    socket = null;
   });
 
   it('should read usbmux message', async function () {
@@ -36,7 +48,7 @@ describe('usbmux', function () {
     await usbmux.listDevices(-1).should.eventually.be.rejected;
   });
 
-  it.skip('should read concatanated message', async function () {
+  it.skip('should read concatenated message', async function () {
     ({server, socket} = await getServerWithFixtures(fixtures.DEVICE_LIST, fixtures.DEVICE_LIST_2));
     usbmux = new Usbmux(socket);
 


### PR DESCRIPTION
Observed this, while going through the code base,

I think the BaseService is iterating by indices rather than actual values. 
Not sure of the implementation/ how it is handled internally, but looked like a bug.

So, Changed for...in loop to for...of to correctly iterate over event names rather than indices