### PR TITLE
refactor: use an object spread instead of Object.assign

### DIFF
--- a/lib/lockdown/index.js
+++ b/lib/lockdown/index.js
@@ -73,11 +73,12 @@ class Lockdown extends BaseServicePlist {
    * @throws {Error} If an unexpected response is received from lockdownd
    */
   async getValue (query = {}, timeout = 5000) {
-    const plist = Object.assign({
+    const plist = {
       Label: LABEL,
       ProtocolVersion: PROTOCOL_VERSION,
-      Request: 'GetValue'
-    }, query);
+      Request: 'GetValue',
+      ...query
+    };
     const data = await this._plistService.sendPlistAndReceive(plist, timeout);
     if (data?.Request === 'GetValue' && !_.isNil(data?.Value)) {
       return data.Value;


### PR DESCRIPTION
use an object spread instead of Object.assign to make it more concise and readable