### PR TITLE
refactor: simplify loop in SyslogDecoder by using for...of

### DIFF
--- a/lib/syslog/transformer/syslog-decoder.js
+++ b/lib/syslog/transformer/syslog-decoder.js
@@ -69,13 +69,13 @@ class SyslogDecoder extends Stream.Transform {
   }
 
   _decode (data) {
-    for (let i = 0; i < data.length; i++) {
+    for (const byte of data) {
       // Don't store the null delimiter messages
-      if (data[i] === NULL_DELIMITER_CODE) {
+      if (byte === NULL_DELIMITER_CODE) {
         continue;
       }
       // Push the data when new line is sent
-      if (data[i] === NEW_LINE_CODE) {
+      if (byte === NEW_LINE_CODE) {
         if (this.bufferIndex > 0) {
           const stringBuffer = Buffer.allocUnsafe(this.bufferIndex);
           this.buffer.copy(stringBuffer, 0, 0, this.bufferIndex);
@@ -84,7 +84,7 @@ class SyslogDecoder extends Stream.Transform {
         }
         continue;
       }
-      this.buffer[this.bufferIndex] = data[i];
+      this.buffer[this.bufferIndex] = byte;
       this.bufferIndex++;
     }
   }


### PR DESCRIPTION
use for...of for better readability 