### PR TITLE
refactor: replace plistlib.parseBuffer with named import parseBuffer

### DIFF
--- a/lib/instrument/headers.js
+++ b/lib/instrument/headers.js
@@ -1,5 +1,5 @@
 import {archive, unarchive} from './transformer/nskeyed';
-import plistlib from 'bplist-parser';
+import { parseBuffer } from 'bplist-parser';
 import _ from 'lodash';
 
 const DTX_MESSAGE_PAYLOAD_HEADER_LENGTH = 16;
@@ -423,7 +423,7 @@ class DTXMessage {
     const data = payloadBuf.slice(cursor, cursor + payloadBuf.length);
     ret.selector = data;
     if (data.length > 0) {
-      for (const fun of [unarchive, plistlib.parseBuffer]) {
+      for (const fun of [unarchive, parseBuffer]) {
         try {
           ret.selector = fun(data);
           break;

--- a/lib/instrument/transformer/nskeyed.js
+++ b/lib/instrument/transformer/nskeyed.js
@@ -1,4 +1,4 @@
-import plistlib from 'bplist-parser';
+import plistlib, { parseBuffer } from 'bplist-parser';
 import bplistCreate from 'bplist-creator';
 import { parse as uuidParse, stringify as uuidStringify } from 'uuid';
 import _ from 'lodash';
@@ -371,7 +371,7 @@ class Unarchive {
   }
 
   unpackArchiveHeader() {
-    const plist = plistlib.parseBuffer(this.input)[0];
+    const plist = parseBuffer(this.input)[0];
     const createPlistIssue = (/** @type {string} */ message) => {
       try {
         log.debug(`Source plist: ${_.truncate(JSON.stringify(plist), {length: 250})}`);


### PR DESCRIPTION
 replace plistlib.parseBuffer with named import parseBuffer for fixing lint warning