### PR TITLE
feat: Bump Node.js version

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,8 +15,8 @@
     "url": "https://github.com/appium/appium-ios-device/issues"
   },
   "engines": {
-    "node": ">=14",
-    "npm": ">=8"
+    "node": "^20.19.0 || ^22.12.0 || >=24.0.0",
+    "npm": ">=10"
   },
   "main": "./build/index.js",
   "bin": {},
@@ -31,7 +31,7 @@
     "CHANGELOG.md"
   ],
   "dependencies": {
-    "@appium/support": "^6.0.0",
+    "@appium/support": "^7.0.0-rc.1",
     "asyncbox": "^3.0.0",
     "axios": "^1.6.7",
     "bluebird": "^3.1.1",
@@ -57,9 +57,9 @@
     "singleQuote": true
   },
   "devDependencies": {
-    "@appium/eslint-config-appium-ts": "^1.x",
-    "@appium/tsconfig": "^0.x",
-    "@appium/types": "^0.x",
+    "@appium/eslint-config-appium-ts": "^2.0.0-rc.1",
+    "@appium/tsconfig": "^1.0.0-rc.1",
+    "@appium/types": "^1.0.0-rc.1",
     "@semantic-release/changelog": "^6.0.1",
     "@semantic-release/git": "^10.0.1",
     "@types/bluebird": "^3.5.38",


### PR DESCRIPTION
BREAKING CHANGE: Required Node.js version has been bumped to ^20.19.0 || ^22.12.0 || >=24.0.0
BREAKING CHANGE: Required npm version has been bumped to >=10