### PR TITLE
feat: Move uuid-specific helpers to this module

### DIFF
--- a/lib/instrument/transformer/nskeyed.js
+++ b/lib/instrument/transformer/nskeyed.js
@@ -1,6 +1,7 @@
 import plistlib, { parseBuffer } from 'bplist-parser';
 import bplistCreate from 'bplist-creator';
-import { parse as uuidParse, stringify as uuidStringify } from 'uuid';
+import { parse as uuidParse } from '../../util/uuid/parse';
+import { stringify as uuidStringify } from '../../util/uuid/stringify';
 import _ from 'lodash';
 import { format as stringFormat } from 'node:util';
 import { log } from '../../logger';

--- a/lib/util/uuid/parse.ts
+++ b/lib/util/uuid/parse.ts
@@ -1,0 +1,59 @@
+/*
+https://github.com/uuidjs/uuid
+
+The MIT License (MIT)
+
+Copyright (c) 2010-2020 Robert Kieffer and other contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+associated documentation files (the "Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the
+following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial
+portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT
+LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE
+OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+import { validate } from './validate';
+
+export function parse(uuid: string): Uint8Array {
+  if (!validate(uuid)) {
+    throw TypeError('Invalid UUID');
+  }
+
+  let v: number;
+  return Uint8Array.of(
+    (v = parseInt(uuid.slice(0, 8), 16)) >>> 24,
+    (v >>> 16) & 0xff,
+    (v >>> 8) & 0xff,
+    v & 0xff,
+
+    // Parse ........-####-....-....-............
+    (v = parseInt(uuid.slice(9, 13), 16)) >>> 8,
+    v & 0xff,
+
+    // Parse ........-....-####-....-............
+    (v = parseInt(uuid.slice(14, 18), 16)) >>> 8,
+    v & 0xff,
+
+    // Parse ........-....-....-####-............
+    (v = parseInt(uuid.slice(19, 23), 16)) >>> 8,
+    v & 0xff,
+
+    // Parse ........-....-....-....-############
+    // (Use "/" to avoid 32-bit truncation when bit-shifting high-order bytes)
+    ((v = parseInt(uuid.slice(24, 36), 16)) / 0x10000000000) & 0xff,
+    (v / 0x100000000) & 0xff,
+    (v >>> 24) & 0xff,
+    (v >>> 16) & 0xff,
+    (v >>> 8) & 0xff,
+    v & 0xff
+  );
+}

--- a/lib/util/uuid/stringify.ts
+++ b/lib/util/uuid/stringify.ts
@@ -1,0 +1,71 @@
+/*
+https://github.com/uuidjs/uuid
+
+The MIT License (MIT)
+
+Copyright (c) 2010-2020 Robert Kieffer and other contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+associated documentation files (the "Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the
+following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial
+portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT
+LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE
+OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+import { validate} from './validate';
+import _ from 'lodash';
+
+/**
+ * Convert array of 16 byte values to UUID string format of the form:
+ * XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX
+ */
+const byteToHex: string[] = _.range(256).map((i) => (i + 0x100).toString(16).slice(1));
+
+function unsafeStringify(arr: Uint8Array, offset: number = 0): string {
+  return (
+    byteToHex[arr[offset + 0]] +
+    byteToHex[arr[offset + 1]] +
+    byteToHex[arr[offset + 2]] +
+    byteToHex[arr[offset + 3]] +
+    '-' +
+    byteToHex[arr[offset + 4]] +
+    byteToHex[arr[offset + 5]] +
+    '-' +
+    byteToHex[arr[offset + 6]] +
+    byteToHex[arr[offset + 7]] +
+    '-' +
+    byteToHex[arr[offset + 8]] +
+    byteToHex[arr[offset + 9]] +
+    '-' +
+    byteToHex[arr[offset + 10]] +
+    byteToHex[arr[offset + 11]] +
+    byteToHex[arr[offset + 12]] +
+    byteToHex[arr[offset + 13]] +
+    byteToHex[arr[offset + 14]] +
+    byteToHex[arr[offset + 15]]
+  ).toLowerCase();
+}
+
+export function stringify(arr: Uint8Array, offset: number = 0): string {
+  const uuid = unsafeStringify(arr, offset);
+
+  // Consistency check for valid UUID.  If this throws, it's likely due to one
+  // of the following:
+  // - One or more input array values don't map to a hex octet (leading to
+  // "undefined" in the uuid)
+  // - Invalid input values for the RFC `version` or `variant` fields
+  if (!validate(uuid)) {
+    throw TypeError('Stringified UUID is invalid');
+  }
+
+  return uuid;
+}

--- a/lib/util/uuid/validate.ts
+++ b/lib/util/uuid/validate.ts
@@ -1,0 +1,28 @@
+/*
+https://github.com/uuidjs/uuid
+
+The MIT License (MIT)
+
+Copyright (c) 2010-2020 Robert Kieffer and other contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+associated documentation files (the "Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the
+following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial
+portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT
+LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE
+OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+const REGEX = /^(?:[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$/i;
+
+export function validate(uuid: unknown): boolean {
+  return typeof uuid === 'string' && REGEX.test(uuid);
+}

--- a/package.json
+++ b/package.json
@@ -39,8 +39,7 @@
     "bplist-parser": "^0.x",
     "lodash": "^4.17.15",
     "semver": "^7.0.0",
-    "source-map-support": "^0.x",
-    "uuid": "^11.0.1"
+    "source-map-support": "^0.x"
   },
   "scripts": {
     "build": "tsc -b",

--- a/test/instrument/nskeyed-specs.js
+++ b/test/instrument/nskeyed-specs.js
@@ -1,5 +1,5 @@
 import {unarchive, archive, NSURL, NSUUID, NSDate} from '../../lib/instrument/transformer/nskeyed';
-import {v4} from 'uuid';
+import {util} from '@appium/support';
 
 describe('NSKeyedArchive', function () {
   let chai;
@@ -39,7 +39,7 @@ describe('NSKeyedArchive', function () {
   });
 
   it('NSKeyedArchive encode/decode for NSUUID', function () {
-    const uuid = v4();
+    const uuid = util.uuidV4();
     const data = {'NSUUID': new NSUUID(uuid)};
     const archiveData = archive(data);
     const unArchiveData = unarchive(archiveData);


### PR DESCRIPTION
The uuid module has recently switched to ESM-only, which prevents us from using it as the corresponding class method cannot be made asynchronous. That is why I have just copied two methods we use to parse and stringify udids from the original lib (the original license text is preserved), and excluded the `udid` module from dependencies